### PR TITLE
Include field complexity callback in schema recreation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,18 +9,16 @@
         "graphql-tools"
     ],
     "require": {
-        "php": ">=7.2",
-        "webonyx/graphql-php": "~0.13",
+        "php": "^8.2",
+        "webonyx/graphql-php": "^14.0",
         "ext-json": "*"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "3.4.2",
-        "phpunit/phpunit": "^7.3 || ^8.0",
+        "squizlabs/php_codesniffer": "^3.4",
+        "phpunit/phpunit": "^9.1",
         "react/promise": "^2.7",
-        "doctrine/coding-standard": "^5.0",
-        "phpstan/phpstan": "^0.10.5",
-        "phpstan/phpstan-phpunit": "^0.10.0",
-        "phpstan/phpstan-strict-rules": "^0.10.1"
+        "doctrine/coding-standard": "^13.0",
+        "phpstan/phpstan": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",
         "phpunit/phpunit": "^9.1",
-        "react/promise": "^2.7",
+        "react/promise": "^3.2",
         "doctrine/coding-standard": "^13.0",
         "phpstan/phpstan": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "webonyx/graphql-php": "^14.0",
+        "webonyx/graphql-php": "^15.0",
         "ext-json": "*"
     },
     "require-dev": {
@@ -40,5 +40,10 @@
         "test": "phpunit",
         "lint": "phpcs",
         "static-analysis": "phpstan analyse --ansi"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,8 +4,3 @@ parameters:
         paths:
         - %currentWorkingDirectory%/src
         - %currentWorkingDirectory%/tests
-
-        includes:
-        - vendor/phpstan/phpstan-phpunit/extension.neon
-        - vendor/phpstan/phpstan-phpunit/rules.neon
-        - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-        bootstrap="vendor/autoload.php"
->
-    <php>
-        <ini name="error_reporting" value="E_ALL"/>
-    </php>
-
-    <testsuites>
-        <testsuite name="t3n/graphql-tools Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="E_ALL"/>
+  </php>
+  <testsuites>
+    <testsuite name="t3n/graphql-tools Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Generate/AddSchemaLevelResolveFunction.php
+++ b/src/Generate/AddSchemaLevelResolveFunction.php
@@ -8,13 +8,14 @@ use GraphQL\Executor\Executor;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Schema;
+
 use function array_filter;
 use function mt_getrandmax;
 use function mt_rand;
 
 class AddSchemaLevelResolveFunction
 {
-    public static function invoke(Schema $schema, callable $fn) : void
+    public static function invoke(Schema $schema, callable $fn): void
     {
         /** @var ObjectType[] $rootTypes */
         $rootTypes = array_filter([
@@ -39,7 +40,7 @@ class AddSchemaLevelResolveFunction
         }
     }
 
-    protected static function wrapResolver(?callable $innerResolver, callable $outerResolver) : callable
+    protected static function wrapResolver(callable|null $innerResolver, callable $outerResolver): callable
     {
         return static function ($obj, $args, &$ctx, ResolveInfo $info) use ($innerResolver, $outerResolver) {
             $root = $outerResolver($obj, $args, $ctx, $info);
@@ -52,7 +53,7 @@ class AddSchemaLevelResolveFunction
         };
     }
 
-    protected static function runAtMostOncePerRequest(callable $fn) : callable
+    protected static function runAtMostOncePerRequest(callable $fn): callable
     {
         $value = null;
         // cast to string to all $randomNumber to be an array key

--- a/src/Generate/AssertResolveFunctionsPresent.php
+++ b/src/Generate/AssertResolveFunctionsPresent.php
@@ -9,15 +9,14 @@ use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use TypeError;
+
 use function count;
 use function is_callable;
 
 class AssertResolveFunctionsPresent
 {
-    /**
-     * @param mixed[] $resolverValidationOptions
-     */
-    public static function invoke(Schema $schema, array $resolverValidationOptions = []) : void
+    /** @param mixed[] $resolverValidationOptions */
+    public static function invoke(Schema $schema, array $resolverValidationOptions = []): void
     {
         $requireResolversForArgs      = $resolverValidationOptions['requireResolversForArgs'] ?? false;
         $requireResolversForNonScalar = $resolverValidationOptions['requireResolversForNonScalar'] ?? false;
@@ -27,7 +26,7 @@ class AssertResolveFunctionsPresent
             throw new TypeError(
                 'requireResolversForAllFields takes precedence over the more specific assertions. ' .
                 'Please configure either requireResolversForAllFields or requireResolversForArgs / ' .
-                'requireResolversForNonScalar, but not a combination of them.'
+                'requireResolversForNonScalar, but not a combination of them.',
             );
         }
 
@@ -36,12 +35,12 @@ class AssertResolveFunctionsPresent
             static function (
                 FieldDefinition $field,
                 string $typeName,
-                string $fieldName
+                string $fieldName,
             ) use (
                 $requireResolversForAllFields,
                 $requireResolversForArgs,
-                $requireResolversForNonScalar
-            ) : void {
+                $requireResolversForNonScalar,
+            ): void {
                 if ($requireResolversForAllFields) {
                     static::expectResolveFunction($field, $typeName, $fieldName);
                 }
@@ -55,14 +54,12 @@ class AssertResolveFunctionsPresent
                 }
 
                 static::expectResolveFunction($field, $typeName, $fieldName);
-            }
+            },
         );
     }
 
-    /**
-     * @throws SchemaError
-     */
-    protected static function expectResolveFunction(FieldDefinition $field, string $typeName, string $fieldName) : void
+    /** @throws SchemaError */
+    protected static function expectResolveFunction(FieldDefinition $field, string $typeName, string $fieldName): void
     {
         if (! $field->resolveFn) {
             throw new TypeError('Resolve function missing for "' . $typeName . '.' . $fieldName . '"');

--- a/src/Generate/AttachConnectorsToContext.php
+++ b/src/Generate/AttachConnectorsToContext.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Schema;
 use GraphQLTools\Utils;
 use stdClass;
 use TypeError;
+
 use function call_user_func;
 use function class_exists;
 use function count;
@@ -20,10 +21,8 @@ use function is_string;
 
 class AttachConnectorsToContext
 {
-    /**
-     * @param mixed[] $connectors
-     */
-    public static function invoke(Schema $schema, array $connectors) : void
+    /** @param mixed[] $connectors */
+    public static function invoke(Schema $schema, array $connectors): void
     {
         if (count($connectors) === 0) {
             throw new TypeError('Expected connectors to not be an empty array');
@@ -42,6 +41,7 @@ class AttachConnectorsToContext
         $attachconnectorFn = static function ($root, array $args, &$ctx) use ($connectors) {
             if (! is_object($ctx)) {
                 $contextType = gettype($ctx);
+
                 throw new Exception('Cannot attach connector because context is not an object: ' . $contextType);
             }
 

--- a/src/Generate/AttachDirectiveResolvers.php
+++ b/src/Generate/AttachDirectiveResolvers.php
@@ -8,14 +8,13 @@ use GraphQL\Executor\Executor;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Schema;
 use GraphQLTools\SchemaDirectiveVisitor;
+
 use function call_user_func;
 
 class AttachDirectiveResolvers
 {
-    /**
-     * @param mixed[] $directiveResolvers
-     */
-    public static function invoke(Schema $schema, array $directiveResolvers) : void
+    /** @param mixed[] $directiveResolvers */
+    public static function invoke(Schema $schema, array $directiveResolvers): void
     {
         $schemaDirectives = [];
         foreach ($directiveResolvers as $directiveName => $resolver) {
@@ -28,10 +27,8 @@ class AttachDirectiveResolvers
                     $this->resolver = $resolver;
                 }
 
-                /**
-                 * @param mixed[] $details
-                 */
-                public function visitFieldDefinition(FieldDefinition $field, array $details) : void
+                /** @param mixed[] $details */
+                public function visitFieldDefinition(FieldDefinition $field, array $details): void
                 {
                     $resolver         = $this->resolver;
                     $originalResolver = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
@@ -48,7 +45,7 @@ class AttachDirectiveResolvers
                             $source,
                             $directiveArgs,
                             $context,
-                            $info
+                            $info,
                         );
                     };
                 }

--- a/src/Generate/AttachDirectiveResolvers.php
+++ b/src/Generate/AttachDirectiveResolvers.php
@@ -28,7 +28,7 @@ class AttachDirectiveResolvers
                 }
 
                 /** @param mixed[] $details */
-                public function visitFieldDefinition(FieldDefinition $field, array $details): void
+                public function visitFieldDefinition(FieldDefinition $field, array $details): mixed
                 {
                     $resolver         = $this->resolver;
                     $originalResolver = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
@@ -48,6 +48,8 @@ class AttachDirectiveResolvers
                             $info,
                         );
                     };
+
+                    return null;
                 }
             };
         }

--- a/src/Generate/BuildSchemaFromTypeDefinitions.php
+++ b/src/Generate/BuildSchemaFromTypeDefinitions.php
@@ -9,9 +9,7 @@ use GraphQL\Language\AST\Node;
 use GraphQL\Language\Parser;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildSchema;
-use GraphQL\Utils\SchemaExtender;
 
-use function count;
 use function gettype;
 use function is_array;
 use function is_string;
@@ -50,13 +48,7 @@ class BuildSchemaFromTypeDefinitions
         }
 
         $backcompatOptions = ['commentDescriptions' => true];
-        $schema            = BuildSchema::buildAST($astDocument, null, $backcompatOptions);
 
-        $extensionsAst = ExtractExtensionDefinitions::invoke($astDocument);
-        if (count($extensionsAst->definitions) > 0) {
-            $schema = SchemaExtender::extend($schema, $extensionsAst, $backcompatOptions);
-        }
-
-        return $schema;
+        return BuildSchema::buildAST($astDocument, null, $backcompatOptions);
     }
 }

--- a/src/Generate/BuildSchemaFromTypeDefinitions.php
+++ b/src/Generate/BuildSchemaFromTypeDefinitions.php
@@ -11,7 +11,6 @@ use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildSchema;
 use GraphQL\Utils\SchemaExtender;
 
-use function assert;
 use function count;
 use function gettype;
 use function is_array;
@@ -29,11 +28,10 @@ class BuildSchemaFromTypeDefinitions
      * @param string|string[]|DocumentNode $typeDefinitions
      * @param mixed[]|null                 $parseOptions
      */
-    public static function invoke(string|array|DocumentNode $typeDefinitions, array|null $parseOptions = null): Schema
+    public static function invoke(mixed $typeDefinitions, array|null $parseOptions = null): Schema
     {
         $myDefinitions = $typeDefinitions;
         $astDocument   = null;
-        assert($astDocument instanceof DocumentNode);
 
         if (static::isDocumentNode($typeDefinitions)) {
             $astDocument = $typeDefinitions;

--- a/src/Generate/ChainResolvers.php
+++ b/src/Generate/ChainResolvers.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace GraphQLTools\Generate;
 
 use GraphQL\Executor\Executor;
+
 use function array_reduce;
 use function is_callable;
 
 class ChainResolvers
 {
-    /**
-     * @param callable[] $resolvers
-     */
-    public static function invoke(array $resolvers) : callable
+    /** @param callable[] $resolvers */
+    public static function invoke(array $resolvers): callable
     {
         return static function ($root, $args, $ctx, $info) use ($resolvers) {
             return array_reduce($resolvers, static function ($prev, $curResolver) use ($args, $ctx, $info) {

--- a/src/Generate/CheckForResolveTypeResolver.php
+++ b/src/Generate/CheckForResolveTypeResolver.php
@@ -8,15 +8,12 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Schema;
 
-use function assert;
-
 class CheckForResolveTypeResolver
 {
     /** @throws SchemaError */
     public static function invoke(Schema $schema, bool|null $requireResolversForResolveType = null): void
     {
-        foreach ($schema->getTypeMap() as $typeName => $type) {
-            assert($typeName instanceof UnionType || $typeName instanceof InterfaceType);
+        foreach ($schema->getTypeMap() as $type) {
             if (! ($type instanceof UnionType || $type instanceof InterfaceType)) {
                 continue;
             }

--- a/src/Generate/CheckForResolveTypeResolver.php
+++ b/src/Generate/CheckForResolveTypeResolver.php
@@ -8,17 +8,15 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Schema;
 
+use function assert;
+
 class CheckForResolveTypeResolver
 {
-    /**
-     * @throws SchemaError
-     */
-    public static function invoke(Schema $schema, ?bool $requireResolversForResolveType = null) : void
+    /** @throws SchemaError */
+    public static function invoke(Schema $schema, bool|null $requireResolversForResolveType = null): void
     {
-        /**
-         * @var UnionType|InterfaceType $typeName
-         */
         foreach ($schema->getTypeMap() as $typeName => $type) {
+            assert($typeName instanceof UnionType || $typeName instanceof InterfaceType);
             if (! ($type instanceof UnionType || $type instanceof InterfaceType)) {
                 continue;
             }
@@ -35,7 +33,7 @@ class CheckForResolveTypeResolver
                 throw new SchemaError(
                     'Type "' . $type->name . '" is missing a "__resolveType" resolver. ' .
                     'Pass false into "resolverValidationOptions.requireResolversForResolveType" ' .
-                    'to disable this warning.'
+                    'to disable this warning.',
                 );
             }
         }

--- a/src/Generate/ConcatenateTypeDefs.php
+++ b/src/Generate/ConcatenateTypeDefs.php
@@ -6,7 +6,7 @@ namespace GraphQLTools\Generate;
 
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\Printer;
-use const PHP_EOL;
+
 use function array_map;
 use function array_merge;
 use function array_reduce;
@@ -17,6 +17,8 @@ use function is_callable;
 use function is_string;
 use function trim;
 
+use const PHP_EOL;
+
 class ConcatenateTypeDefs
 {
     /**
@@ -25,7 +27,7 @@ class ConcatenateTypeDefs
      *
      * @throws SchemaError
      */
-    public static function invoke(array $typeDefinitionsAry, array &$calledFunctionRefs = []) : string
+    public static function invoke(array $typeDefinitionsAry, array &$calledFunctionRefs = []): string
     {
         $resolvedTypeDefinitions = [];
         foreach ($typeDefinitionsAry as $typeDef) {
@@ -42,6 +44,7 @@ class ConcatenateTypeDefs
                 $resolvedTypeDefinitions[] = trim($typeDef);
             } else {
                 $type = gettype($typeDef);
+
                 throw new SchemaError('typeDef array must contain only strings and functions, got ' . $type);
             }
         }
@@ -53,9 +56,9 @@ class ConcatenateTypeDefs
                     static function ($x) {
                         return trim($x);
                     },
-                    $resolvedTypeDefinitions
-                )
-            )
+                    $resolvedTypeDefinitions,
+                ),
+            ),
         );
     }
 
@@ -64,7 +67,7 @@ class ConcatenateTypeDefs
      *
      * @return mixed[]
      */
-    protected static function uniq(array $array) : array
+    protected static function uniq(array $array): array
     {
         return array_reduce(
             $array,
@@ -73,7 +76,7 @@ class ConcatenateTypeDefs
                     ? array_merge($accumulator, [$currentValue])
                     : $accumulator;
             },
-            []
+            [],
         );
     }
 }

--- a/src/Generate/DecorateWithLogger.php
+++ b/src/Generate/DecorateWithLogger.php
@@ -10,17 +10,18 @@ use GraphQL\Executor\Executor;
 use GraphQL\Executor\Promise\Promise;
 use GraphQLTools\Logger;
 use Throwable;
+
 use const PHP_EOL;
 
 class DecorateWithLogger
 {
-    public static function invoke(?callable $fn, Logger $logger, string $hint) : callable
+    public static function invoke(callable|null $fn, Logger $logger, string $hint): callable
     {
         if ($fn === null) {
             $fn = [Executor::class, 'defaultFieldResolver'];
         }
 
-        $logError = static function (Throwable $e) use ($logger, $hint) : void {
+        $logError = static function (Throwable $e) use ($logger, $hint): void {
             $message = $e->getMessage();
             if ($hint) {
                 $message = 'Error in resolver ' . $hint . PHP_EOL . $message;
@@ -37,6 +38,7 @@ class DecorateWithLogger
                 if ($result instanceof Promise) {
                     $result->then(null, static function (Error $reason) use ($logError) {
                         $logError($reason);
+
                         return $reason;
                     });
                 }
@@ -44,6 +46,7 @@ class DecorateWithLogger
                 return $result;
             } catch (Throwable $e) {
                 $logError($e);
+
                 throw $e;
             }
         };

--- a/src/Generate/ExtendResolversFromInterfaces.php
+++ b/src/Generate/ExtendResolversFromInterfaces.php
@@ -7,6 +7,7 @@ namespace GraphQLTools\Generate;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Schema;
+
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -19,11 +20,11 @@ class ExtendResolversFromInterfaces
      *
      * @return mixed[]
      */
-    public static function invoke(Schema $schema, array $resolvers) : array
+    public static function invoke(Schema $schema, array $resolvers): array
     {
         $typeNames = array_keys(array_merge(
             $schema->getTypeMap(),
-            $resolvers
+            $resolvers,
         ));
 
         $extendedResolvers = [];
@@ -41,7 +42,7 @@ class ExtendResolversFromInterfaces
                     static function ($resolvers, $iFaceResolvers) {
                         return array_merge($resolvers, $iFaceResolvers);
                     },
-                    $typeResolvers ?? []
+                    $typeResolvers ?? [],
                 );
             } else {
                 if ($typeResolvers) {

--- a/src/Generate/ExtractExtensionDefinitions.php
+++ b/src/Generate/ExtractExtensionDefinitions.php
@@ -12,18 +12,19 @@ use GraphQL\Language\AST\InterfaceTypeExtensionNode;
 use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\ObjectTypeExtensionNode;
 use GraphQL\Language\AST\UnionTypeExtensionNode;
+
 use function array_filter;
 use function array_values;
 use function iterator_to_array;
 
 class ExtractExtensionDefinitions
 {
-    public static function invoke(DocumentNode $ast) : DocumentNode
+    public static function invoke(DocumentNode $ast): DocumentNode
     {
         $definitions   = $ast->definitions instanceof NodeList
             ? iterator_to_array($ast->definitions->getIterator())
             : $ast->definitions;
-        $extensionDefs = array_filter($definitions, static function (DefinitionNode $def) : bool {
+        $extensionDefs = array_filter($definitions, static function (DefinitionNode $def): bool {
             return $def instanceof ObjectTypeExtensionNode ||
                 $def instanceof InterfaceTypeExtensionNode ||
                 $def instanceof InputObjectTypeExtensionNode ||
@@ -33,6 +34,7 @@ class ExtractExtensionDefinitions
 
         $extensionAst              = clone$ast;
         $extensionAst->definitions = array_values($extensionDefs);
+
         return $extensionAst;
     }
 }

--- a/src/Generate/ExtractExtensionDefinitions.php
+++ b/src/Generate/ExtractExtensionDefinitions.php
@@ -12,18 +12,16 @@ use GraphQL\Language\AST\InterfaceTypeExtensionNode;
 use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\ObjectTypeExtensionNode;
 use GraphQL\Language\AST\UnionTypeExtensionNode;
+use GraphQLTools\Utils;
 
 use function array_filter;
 use function array_values;
-use function iterator_to_array;
 
 class ExtractExtensionDefinitions
 {
     public static function invoke(DocumentNode $ast): DocumentNode
     {
-        $definitions   = $ast->definitions instanceof NodeList
-            ? iterator_to_array($ast->definitions->getIterator())
-            : $ast->definitions;
+        $definitions   = Utils::toArray($ast->definitions);
         $extensionDefs = array_filter($definitions, static function (DefinitionNode $def): bool {
             return $def instanceof ObjectTypeExtensionNode ||
                 $def instanceof InterfaceTypeExtensionNode ||
@@ -33,7 +31,7 @@ class ExtractExtensionDefinitions
         });
 
         $extensionAst              = clone$ast;
-        $extensionAst->definitions = array_values($extensionDefs);
+        $extensionAst->definitions = new NodeList(array_values($extensionDefs));
 
         return $extensionAst;
     }

--- a/src/Generate/ForEachField.php
+++ b/src/Generate/ForEachField.php
@@ -7,11 +7,12 @@ namespace GraphQLTools\Generate;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
+
 use function substr;
 
 class ForEachField
 {
-    public static function invoke(Schema $schema, callable $fn) : void
+    public static function invoke(Schema $schema, callable $fn): void
     {
         $typeMap = $schema->getTypeMap();
 

--- a/src/GraphQLTools.php
+++ b/src/GraphQLTools.php
@@ -16,10 +16,8 @@ use GraphQLTools\Transforms\TransformSchema;
 
 class GraphQLTools
 {
-    /**
-     * @param mixed[] $options
-     */
-    public static function makeExecutableSchema(array $options) : Schema
+    /** @param mixed[] $options */
+    public static function makeExecutableSchema(array $options): Schema
     {
         return MakeExecutableSchema::invoke($options);
     }
@@ -30,40 +28,32 @@ class GraphQLTools
      * @param mixed[]|null   $legacyInputValidationOptions
      */
     public static function addResolveFunctionsToSchema(
-        $options,
-        $legacyInputResolvers = null,
-        ?array $legacyInputValidationOptions = null
-    ) : Schema {
+        Schema|array $options,
+        array|null $legacyInputResolvers = null,
+        array|null $legacyInputValidationOptions = null,
+    ): Schema {
         return AddResolveFunctionsToSchema::invoke($options, $legacyInputResolvers, $legacyInputValidationOptions);
     }
 
-    public static function addSchemaLevelResolveFunction(Schema $schema, callable $resolveFn) : void
+    public static function addSchemaLevelResolveFunction(Schema $schema, callable $resolveFn): void
     {
         AddSchemaLevelResolveFunction::invoke($schema, $resolveFn);
     }
 
-    /**
-     * @param mixed[] $options
-     *
-     * @return mixed
-     */
-    public static function delegateToSchema(array $options)
+    /** @param mixed[] $options */
+    public static function delegateToSchema(array $options): mixed
     {
         return DelegateToSchema::invoke($options);
     }
 
-    /**
-     * @param mixed[] $options
-     */
-    public static function mergeSchemas(array $options) : Schema
+    /** @param mixed[] $options */
+    public static function mergeSchemas(array $options): Schema
     {
         return MergeSchemas::invoke($options);
     }
 
-    /**
-     * @param Transform[] $transforms
-     */
-    public static function transformSchema(Schema $targetSchema, array $transforms) : Schema
+    /** @param Transform[] $transforms */
+    public static function transformSchema(Schema $targetSchema, array $transforms): Schema
     {
         return TransformSchema::invoke($targetSchema, $transforms);
     }
@@ -72,7 +62,7 @@ class GraphQLTools
      * @param string|string[]|DocumentNode $typeDefinitions
      * @param mixed[]|null                 $parseOptions
      */
-    public static function buildSchemaFromTypeDefinitions($typeDefinitions, ?array $parseOptions = null) : Schema
+    public static function buildSchemaFromTypeDefinitions(string|array|DocumentNode $typeDefinitions, array|null $parseOptions = null): Schema
     {
         return BuildSchemaFromTypeDefinitions::invoke($typeDefinitions, $parseOptions);
     }

--- a/src/IsSpecifiedScalarType.php
+++ b/src/IsSpecifiedScalarType.php
@@ -15,7 +15,7 @@ use GraphQL\Type\Definition\Type;
 class IsSpecifiedScalarType
 {
     /** @var string[] */
-    public static $specifiedScalarTypes = [
+    public static array $specifiedScalarTypes = [
         StringType::class,
         IntType::class,
         FloatType::class,
@@ -23,10 +23,7 @@ class IsSpecifiedScalarType
         IDType::class,
     ];
 
-    /**
-     * @param mixed $type
-     */
-    public static function invoke($type) : bool
+    public static function invoke(mixed $type): bool
     {
         if (! $type instanceof NamedType) {
             return false;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -8,5 +8,5 @@ use Throwable;
 
 interface Logger
 {
-    public function log(Throwable $error) : void;
+    public function log(Throwable $error): void;
 }

--- a/src/MakeExecutableSchema.php
+++ b/src/MakeExecutableSchema.php
@@ -15,6 +15,7 @@ use GraphQLTools\Generate\BuildSchemaFromTypeDefinitions;
 use GraphQLTools\Generate\DecorateWithLogger;
 use GraphQLTools\Generate\ForEachField;
 use GraphQLTools\Generate\SchemaError;
+
 use function array_filter;
 use function array_reduce;
 use function is_array;
@@ -28,17 +29,15 @@ class MakeExecutableSchema
      * @param mixed[]|null   $legacyInputValidationOptions
      */
     public static function addResolveFunctionsToSchema(
-        $options,
-        ?array $legacyInputResolvers = null,
-        ?array $legacyInputValidationOptions = null
-    ) : Schema {
+        array|Schema $options,
+        array|null $legacyInputResolvers = null,
+        array|null $legacyInputValidationOptions = null,
+    ): Schema {
         return AddResolveFunctionsToSchema::invoke($options, $legacyInputResolvers, $legacyInputValidationOptions);
     }
 
-    /**
-     * @param mixed[] $options
-     */
-    public static function invoke(array $options) : Schema
+    /** @param mixed[] $options */
+    public static function invoke(array $options): Schema
     {
         $typeDefs                       = $options['typeDefs'] ?? null;
         $resolvers                      = $options['resolvers'] ?? [];
@@ -63,7 +62,7 @@ class MakeExecutableSchema
         }
 
         if (Utils::isNumericArray($resolvers)) {
-            $resolverMap = array_filter($resolvers, static function (array $resolverObj) : bool {
+            $resolverMap = array_filter($resolvers, static function (array $resolverObj): bool {
                 return ! Utils::isNumericArray($resolverObj);
             });
 
@@ -106,14 +105,14 @@ class MakeExecutableSchema
         return $schema;
     }
 
-    public static function addErrorLoggingToSchema(Schema $schema, Logger $logger) : void
+    public static function addErrorLoggingToSchema(Schema $schema, Logger $logger): void
     {
         ForEachField::invoke(
             $schema,
-            static function (FieldDefinition $field, string $typeName, string $fieldName) use ($logger) : void {
+            static function (FieldDefinition $field, string $typeName, string $fieldName) use ($logger): void {
                 $errorHint        = $typeName . '.' . $fieldName;
                 $field->resolveFn = DecorateWithLogger::invoke($field->resolveFn, $logger, $errorHint);
-            }
+            },
         );
     }
 }

--- a/src/MergeDeep.php
+++ b/src/MergeDeep.php
@@ -14,7 +14,7 @@ class MergeDeep
      *
      * @return mixed[]
      */
-    public static function invoke(array $target, array $source) : array
+    public static function invoke(array $target, array $source): array
     {
         $output = $target;
         foreach ($source as $key => $value) {
@@ -28,6 +28,7 @@ class MergeDeep
                 $output[$key] = $value;
             }
         }
+
         return $output;
     }
 }

--- a/src/Mock.php
+++ b/src/Mock.php
@@ -71,8 +71,7 @@ class Mock
         };
     }
 
-    /** @var null object */
-    protected static null $defaultMocks = null;
+    protected static object|null $defaultMocks = null;
 
     protected static function getDefaultMockMap(): object
     {
@@ -239,8 +238,6 @@ class Mock
                 }
 
                 if ($fieldType instanceof UnionType || $fieldType instanceof InterfaceType) {
-                    $implementationType = null;
-                    assert($implementationType instanceof ObjectType);
                     if (isset($mocks[$fieldType->name])) {
                         $interfaceMockObj = $mocks[$fieldType->name]($root, $args, $context, $info);
                         if (! $interfaceMockObj || ! isset($interfaceMockObj['__typename'])) {
@@ -252,6 +249,8 @@ class Mock
                         $possibleTypes      = $schema->getPossibleTypes($fieldType);
                         $implementationType = static::getRandomElement($possibleTypes);
                     }
+
+                    assert($implementationType instanceof ObjectType);
 
                     return array_merge(
                         ['__typename' => $implementationType->name],

--- a/src/Mock/MockList.php
+++ b/src/Mock/MockList.php
@@ -7,6 +7,7 @@ namespace GraphQLTools\Mock;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
+
 use function array_fill;
 use function count;
 use function is_array;
@@ -14,35 +15,24 @@ use function rand;
 
 class MockList
 {
-    /** @var int|int[] */
-    private $len;
     /** @var callable */
     private $wrappedFunction;
 
-    /**
-     * @param int|int[] $len
-     */
-    public function __construct($len, ?callable $wrappedFunction = null)
+    /** @param int|int[] $len */
+    public function __construct(private int|array $len, callable|null $wrappedFunction = null)
     {
-        $this->len             = $len;
         $this->wrappedFunction = $wrappedFunction;
     }
 
-    /**
-     * @param mixed $root
-     * @param mixed $args
-     * @param mixed $context
-     *
-     * @return mixed[]
-     */
+    /** @return mixed[] */
     public function mock(
-        $root,
-        $args,
-        $context,
+        mixed $root,
+        mixed $args,
+        mixed $context,
         ResolveInfo $info,
         ListOfType $fieldType,
-        callable $mockTypeFunc
-    ) : array {
+        callable $mockTypeFunc,
+    ): array {
         $arr = null;
         if (is_array($this->len)) {
             $arr = array_fill(0, rand($this->len[0], $this->len[1]), null);
@@ -51,7 +41,7 @@ class MockList
         }
 
         $wrappedFunction = $this->wrappedFunction;
-        for ($i = 0; $i< count($arr); $i++) {
+        for ($i = 0; $i < count($arr); $i++) {
             if ($wrappedFunction) {
                 $res = $wrappedFunction($root, $args, $context, $info);
                 if ($res instanceof MockList) {
@@ -62,7 +52,7 @@ class MockList
                         $context,
                         $info,
                         $nullableType,
-                        $mockTypeFunc
+                        $mockTypeFunc,
                     );
                 } else {
                     $arr[$i] = $res;
@@ -71,6 +61,7 @@ class MockList
                 $arr[$i] = $mockTypeFunc($fieldType->ofType)($root, $args, $context, $info);
             }
         }
+
         return $arr;
     }
 }

--- a/src/Mock/MockList.php
+++ b/src/Mock/MockList.php
@@ -45,7 +45,7 @@ class MockList
             if ($wrappedFunction) {
                 $res = $wrappedFunction($root, $args, $context, $info);
                 if ($res instanceof MockList) {
-                    $nullableType = Type::getNullableType($fieldType->ofType);
+                    $nullableType = Type::getNullableType($fieldType->getWrappedType());
                     $arr[$i]      = $res->mock(
                         $root,
                         $args,
@@ -58,7 +58,7 @@ class MockList
                     $arr[$i] = $res;
                 }
             } else {
-                $arr[$i] = $mockTypeFunc($fieldType->ofType)($root, $args, $context, $info);
+                $arr[$i] = $mockTypeFunc($fieldType->getWrappedType())($root, $args, $context, $info);
             }
         }
 

--- a/src/SchemaDirectiveVisitor.php
+++ b/src/SchemaDirectiveVisitor.php
@@ -66,7 +66,7 @@ class SchemaDirectiveVisitor extends SchemaVisitor
             &$createdVisitors,
         ): array {
             $visitors       = [];
-            $astNode        = $type instanceof Schema ? $type->getAstNode() : ($type->astNode ?? null);
+            $astNode        = $type instanceof Schema ? $type->astNode : ($type->astNode ?? null);
             $directiveNodes = $astNode ? $astNode->directives : null;
 
             if (! $directiveNodes) {

--- a/src/SchemaDirectiveVisitor.php
+++ b/src/SchemaDirectiveVisitor.php
@@ -7,7 +7,6 @@ namespace GraphQLTools;
 use Exception;
 use GraphQL\Executor\Values;
 use GraphQL\Type\Definition\Directive;
-use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\AST;
 
@@ -24,7 +23,7 @@ class SchemaDirectiveVisitor extends SchemaVisitor
     public string $name;
     /** @var mixed[] */
     public array $args;
-    public Type $visitedType;
+    public mixed $visitedType;
     public mixed $context;
 
     /** @param mixed[] $config */

--- a/src/SchemaDirectiveVisitor.php
+++ b/src/SchemaDirectiveVisitor.php
@@ -10,6 +10,8 @@ use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\AST;
+
+use function assert;
 use function count;
 use function preg_match_all;
 use function strlen;
@@ -19,19 +21,14 @@ use function substr;
 
 class SchemaDirectiveVisitor extends SchemaVisitor
 {
-    /** @var string */
-    public $name;
+    public string $name;
     /** @var mixed[] */
-    public $args;
-    /** @var Type */
-    public $visitedType;
-    /** @var mixed */
-    public $context;
+    public array $args;
+    public Type $visitedType;
+    public mixed $context;
 
-    /**
-     * @param mixed[] $config
-     */
-    public function init(array $config) : void
+    /** @param mixed[] $config */
+    public function init(array $config): void
     {
         $this->name        = $config['name'];
         $this->args        = $config['args'];
@@ -40,18 +37,17 @@ class SchemaDirectiveVisitor extends SchemaVisitor
         $this->context     = $config['context'];
     }
 
-    public static function getDirectiveDeclaration(string $directiveName, Schema $schema) : ?Directive
+    public static function getDirectiveDeclaration(string $directiveName, Schema $schema): Directive|null
     {
         return $schema->getDirective($directiveName);
     }
 
     /**
      * @param mixed[] $directiveVisitors
-     * @param mixed   $context
      *
      * @return callable[]
      */
-    public static function visitSchemaDirectives(Schema $schema, array $directiveVisitors, $context = []) : array
+    public static function visitSchemaDirectives(Schema $schema, array $directiveVisitors, mixed $context = []): array
     {
         $declaredDirectives = static::getDeclaredDirectives($schema, $directiveVisitors);
 
@@ -62,14 +58,14 @@ class SchemaDirectiveVisitor extends SchemaVisitor
 
         $visitorSelector = static function (
             $type,
-            string $methodName
+            string $methodName,
         ) use (
             $directiveVisitors,
             $declaredDirectives,
             $schema,
             $context,
-            &$createdVisitors
-        ) : array {
+            &$createdVisitors,
+        ): array {
             $visitors       = [];
             $astNode        = $type instanceof Schema ? $type->getAstNode() : ($type->astNode ?? null);
             $directiveNodes = $astNode ? $astNode->directives : null;
@@ -84,8 +80,8 @@ class SchemaDirectiveVisitor extends SchemaVisitor
                     break;
                 }
 
-                /** @var SchemaDirectiveVisitor $visitorClass */
                 $visitorClass = $directiveVisitors[$directiveName];
+                assert($visitorClass instanceof SchemaDirectiveVisitor);
 
                 if (! $visitorClass::implementsVisitorMethod($methodName)) {
                     break;
@@ -135,7 +131,7 @@ class SchemaDirectiveVisitor extends SchemaVisitor
      *
      * @return Directive[]
      */
-    protected static function getDeclaredDirectives(Schema $schema, array $directiveVisitors) : array
+    protected static function getDeclaredDirectives(Schema $schema, array $directiveVisitors): array
     {
         /** @var Directive[] $declaredDirectives */
         $declaredDirectives = [];
@@ -162,10 +158,12 @@ class SchemaDirectiveVisitor extends SchemaVisitor
 
             foreach ($decl->locations as $loc) {
                 $visitorMethodName = static::directiveLocationToVisitorMethodName($loc);
-                if (SchemaVisitor::implementsVisitorMethod($visitorMethodName)
-                    && ! $visitorClass::implementsVisitorMethod($visitorMethodName)) {
+                if (
+                    SchemaVisitor::implementsVisitorMethod($visitorMethodName)
+                    && ! $visitorClass::implementsVisitorMethod($visitorMethodName)
+                ) {
                     throw new Exception(
-                        'SchemaDirectiveVisitor for @' . $name . ' must implement ' . $visitorMethodName . ' method'
+                        'SchemaDirectiveVisitor for @' . $name . ' must implement ' . $visitorMethodName . ' method',
                     );
                 }
             }
@@ -174,7 +172,7 @@ class SchemaDirectiveVisitor extends SchemaVisitor
         return $declaredDirectives;
     }
 
-    protected static function directiveLocationToVisitorMethodName(string $loc) : string
+    protected static function directiveLocationToVisitorMethodName(string $loc): string
     {
         preg_match_all('/([^_]*)_?/', $loc, $matches);
 

--- a/src/SchemaVisitor.php
+++ b/src/SchemaVisitor.php
@@ -67,52 +67,62 @@ class SchemaVisitor
         return $operation;
     }
 
-    public function visitSchema(Schema $schema): mixed
+    public function visitSchema(Schema $schema): void
     {
     }
 
     public function visitScalar(ScalarType $scalar): mixed
     {
+        return $scalar;
     }
 
     public function visitObject(ObjectType $object): mixed
     {
+        return $object;
     }
 
     /** @param mixed[] $details */
     public function visitFieldDefinition(FieldDefinition $field, array $details): mixed
     {
+        return $field;
     }
 
     /** @param mixed[] $details */
     public function visitArgumentDefinition(FieldArgument $argument, array $details): mixed
     {
+        return $argument;
     }
 
     public function visitInterface(InterfaceType $iface): mixed
     {
+        return $iface;
     }
 
     public function visitUnion(UnionType $union): mixed
     {
+        return $union;
     }
 
     public function visitEnum(EnumType $type): mixed
     {
+        return $type;
     }
 
     /** @param mixed[] $details */
     public function visitEnumValue(EnumValueDefinition $value, array $details): mixed
     {
+        return $value;
     }
 
     public function visitInputObject(InputObjectType $object): mixed
     {
+        return $object;
     }
 
     /** @param mixed[] $details */
     public function visitInputFieldDefinition(InputObjectField $field, array $details): mixed
     {
+        return $field;
     }
 
     public static function doVisitSchema(Schema $schema, callable $visitorSelector): Schema
@@ -178,7 +188,7 @@ class SchemaVisitor
 
             if ($type instanceof InputObjectType) {
                 $newInputObject = $callMethod('visitInputObject', $type);
-                assert($newInputObject instanceof InputObjectType);
+                assert($newInputObject instanceof InputObjectType || $newInputObject === null);
 
                 if ($newInputObject) {
                     $fields = $newInputObject->getFields();
@@ -201,7 +211,7 @@ class SchemaVisitor
 
             if ($type instanceof EnumType) {
                 $newEnum = $callMethod('visitEnum', $type);
-                assert($newEnum instanceof EnumType);
+                assert($newEnum instanceof EnumType || $newEnum === null);
 
                 if ($newEnum) {
                     $values = $newEnum->getValues();
@@ -240,6 +250,7 @@ class SchemaVisitor
 
                 return $newField;
             });
+
             Utils::forceSet($type, 'fields', $fields);
         };
 

--- a/src/SchemaVisitor.php
+++ b/src/SchemaVisitor.php
@@ -6,9 +6,10 @@ namespace GraphQLTools;
 
 use Exception;
 use GraphQL\Language\VisitorOperation;
+use GraphQL\Language\VisitorRemoveNode;
+use GraphQL\Type\Definition\Argument;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\EnumValueDefinition;
-use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InputObjectField;
 use GraphQL\Type\Definition\InputObjectType;
@@ -61,10 +62,7 @@ class SchemaVisitor
 
     public static function removeNode(): VisitorOperation
     {
-        $operation             = new VisitorOperation();
-        $operation->removeNode = true;
-
-        return $operation;
+        return new VisitorRemoveNode();
     }
 
     public function visitSchema(Schema $schema): void
@@ -88,7 +86,7 @@ class SchemaVisitor
     }
 
     /** @param mixed[] $details */
-    public function visitArgumentDefinition(FieldArgument $argument, array $details): mixed
+    public function visitArgumentDefinition(Argument $argument, array $details): mixed
     {
         return $argument;
     }
@@ -239,7 +237,7 @@ class SchemaVisitor
                 if ($newField instanceof FieldDefinition) {
                     static::updateEachKey(
                         $newField->args,
-                        static function (FieldArgument $arg) use ($callMethod, $newField, $type) {
+                        static function (Argument $arg) use ($callMethod, $newField, $type) {
                             return $callMethod('visitArgumentDefinition', $arg, [
                                 'field' => $newField,
                                 'objectType' => $type,
@@ -395,7 +393,7 @@ class SchemaVisitor
                 continue;
             }
 
-            if ($result instanceof VisitorOperation && $result->removeNode) {
+            if ($result instanceof VisitorRemoveNode) {
                 unset($arr[$key]);
                 continue;
             }

--- a/src/SimpleLogger.php
+++ b/src/SimpleLogger.php
@@ -9,20 +9,17 @@ use Throwable;
 class SimpleLogger implements Logger
 {
     /** @var Throwable[] */
-    public $errors;
-    /** @var string|null  */
-    public $name;
+    public array $errors;
     /** @var callable|null  */
     public $callback;
 
-    public function __construct(?string $name = null, ?callable $callback = null)
+    public function __construct(public string|null $name = null, callable|null $callback = null)
     {
-        $this->name     = $name;
         $this->errors   = [];
         $this->callback = $callback;
     }
 
-    public function log(Throwable $error) : void
+    public function log(Throwable $error): void
     {
         $this->errors[] = $error;
         if (! $this->callback) {

--- a/src/Stitching/DefaultMergedResolver.php
+++ b/src/Stitching/DefaultMergedResolver.php
@@ -10,15 +10,13 @@ use GraphQL\Type\Definition\ResolveInfo;
 class DefaultMergedResolver
 {
     /**
-     * @param mixed   $parent
      * @param mixed[] $args
-     * @param mixed   $context
      *
      * @return array|mixed[]|null
      *
      * @throws Error
      */
-    public static function invoke($parent, array $args, $context, ResolveInfo $info)
+    public static function invoke(mixed $parent, array $args, mixed $context, ResolveInfo $info)
     {
         if (! $parent) {
             return null;
@@ -31,8 +29,9 @@ class DefaultMergedResolver
             $error = Error::createLocatedError(
                 new Error($errorResult['error']->message),
                 $info->fieldNodes,
-                $info->path
+                $info->path,
             );
+
             throw $error;
         }
 

--- a/src/Stitching/DefaultMergedResolver.php
+++ b/src/Stitching/DefaultMergedResolver.php
@@ -27,7 +27,7 @@ class DefaultMergedResolver
 
         if ($errorResult['kind'] === 'OWN') {
             $error = Error::createLocatedError(
-                new Error($errorResult['error']->message),
+                new Error($errorResult['error']->getMessage()),
                 $info->fieldNodes,
                 $info->path,
             );

--- a/src/Stitching/DelegateToSchema.php
+++ b/src/Stitching/DelegateToSchema.php
@@ -121,7 +121,7 @@ class DelegateToSchema
     private static function createDocument(
         string $targetField,
         string $targetOperation,
-        array|NodeList $originalSelections,
+        iterable|NodeList $originalSelections,
         array $fragments,
         array|NodeList $variables,
         NameNode|null $operationName,
@@ -131,14 +131,14 @@ class DelegateToSchema
 
         foreach ($originalSelections as $field) {
             assert($field instanceof FieldNode);
-            $fieldSelection = $field->selectionSet ? $field->selectionSet->selections : [];
+            $fieldSelection = $field->selectionSet ? $field->selectionSet->selections : NodeList::create([]);
             $selections     = array_merge($selections, Utils::toArray($fieldSelection));
             $args           = array_merge($args, $field->arguments ? Utils::toArray($field->arguments) : []);
         }
 
         $selectionSet = null;
         if (count($selections) > 0) {
-            $selectionSet = new SelectionSetNode(['selections' => $selections]);
+            $selectionSet = new SelectionSetNode(['selections' => NodeList::create($selections)]);
         }
 
         $rootField = new FieldNode([
@@ -149,7 +149,7 @@ class DelegateToSchema
         ]);
 
         $rootSelectionSet = new SelectionSetNode([
-            'selections' => [$rootField],
+            'selections' => NodeList::create([$rootField]),
         ]);
 
         $operationDefinition = new OperationDefinitionNode([

--- a/src/Stitching/Errors.php
+++ b/src/Stitching/Errors.php
@@ -140,7 +140,7 @@ class Errors
     protected static function concatErrors(array $errors): string
     {
         return implode('\n', array_map(static function (Error $error): string {
-            return $error->message;
+            return $error->getMessage();
         }, $errors));
     }
 

--- a/src/Stitching/Errors.php
+++ b/src/Stitching/Errors.php
@@ -147,7 +147,7 @@ class Errors
     protected static function hasResult(Error $error): bool
     {
         return isset($error->result)
-            || count($error->getExtensions()) > 0
+            || count((array) $error->getExtensions()) > 0
             || ($error->getPrevious() && isset($error->getPrevious()->result));
     }
 }

--- a/src/Stitching/GetResponseKeyFromInfo.php
+++ b/src/Stitching/GetResponseKeyFromInfo.php
@@ -12,7 +12,7 @@ class GetResponseKeyFromInfo
      * Get the key under which the result of this resolver will be placed in the response JSON. Basically, just
      * resolves aliases.
      */
-    public static function invoke(ResolveInfo $info) : string
+    public static function invoke(ResolveInfo $info): string
     {
         return $info->fieldNodes[0]->alias ? $info->fieldNodes[0]->alias->value : $info->fieldName;
     }

--- a/src/Stitching/ResolveFromParentTypename.php
+++ b/src/Stitching/ResolveFromParentTypename.php
@@ -8,16 +8,13 @@ use GraphQL\Error\Error;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
+
 use function is_array;
 
 class ResolveFromParentTypename
 {
-    /**
-     * @param mixed $parent
-     *
-     * @throws Error
-     */
-    public static function invoke($parent, Schema $schema) : Type
+    /** @throws Error */
+    public static function invoke(mixed $parent, Schema $schema): Type
     {
         $parentTypename = is_array($parent) ? ($parent['__typename'] ?? null) : null;
         if (! $parentTypename) {

--- a/src/Stitching/Resolvers.php
+++ b/src/Stitching/Resolvers.php
@@ -16,7 +16,7 @@ class Resolvers
      *
      * @return mixed[]
      */
-    public static function generateProxyingResolvers(Schema $targetSchema, array $transforms, array $mapping) : array
+    public static function generateProxyingResolvers(Schema $targetSchema, array $transforms, array $mapping): array
     {
         $result = [];
         foreach ($mapping as $name => $innerMapping) {
@@ -29,7 +29,7 @@ class Resolvers
                         $targetSchema,
                         $to['operation'],
                         $to['name'],
-                        $transforms
+                        $transforms,
                     ),
                 ];
             }
@@ -38,10 +38,8 @@ class Resolvers
         return $result;
     }
 
-    /**
-     * @return mixed[]
-     */
-    public static function generateSimpleMapping(Schema $targetSchema) : array
+    /** @return mixed[] */
+    public static function generateSimpleMapping(Schema $targetSchema): array
     {
         $query        = $targetSchema->getQueryType();
         $mutation     = $targetSchema->getMutationType();
@@ -63,10 +61,8 @@ class Resolvers
         return $result;
     }
 
-    /**
-     * @return mixed[]
-     */
-    private static function generateMappingFromObjectType(ObjectType $type, string $operation) : array
+    /** @return mixed[] */
+    private static function generateMappingFromObjectType(ObjectType $type, string $operation): array
     {
         $result = [];
         $fields = $type->getFields();
@@ -81,25 +77,23 @@ class Resolvers
         return $result;
     }
 
-    /**
-     * @param mixed[] $transforms
-     */
+    /** @param mixed[] $transforms */
     private static function createProxyingResolver(
         Schema $schema,
         string $operation,
         string $fieldName,
-        array $transforms
-    ) : callable {
+        array $transforms,
+    ): callable {
         return static function (
             $parent,
             $args,
             $context,
-            ResolveInfo $info
+            ResolveInfo $info,
         ) use (
             $schema,
             $operation,
             $fieldName,
-            $transforms
+            $transforms,
         ) {
             return DelegateToSchema::invoke([
                 'schema' => $schema,

--- a/src/Stitching/SchemaRecreation.php
+++ b/src/Stitching/SchemaRecreation.php
@@ -28,12 +28,12 @@ use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
 use GraphQLTools\IsSpecifiedScalarType;
+
 use function array_map;
-use function get_class;
 
 class SchemaRecreation
 {
-    public static function recreateType(NamedType $type, callable $resolveType, bool $keepResolvers) : NamedType
+    public static function recreateType(NamedType $type, callable $resolveType, bool $keepResolvers): NamedType
     {
         if ($type instanceof ObjectType) {
             $fields     = $type->getFields();
@@ -44,10 +44,10 @@ class SchemaRecreation
                 'description' => $type->description,
                 'astNode' => $type->astNode,
                 'isTypeOf' => $keepResolvers ? ($type->config['isTypeOf'] ?? null) : null,
-                'fields' => static function () use ($fields, $resolveType, $keepResolvers) : array {
+                'fields' => static function () use ($fields, $resolveType, $keepResolvers): array {
                     return static::fieldMapToFieldConfigMap($fields, $resolveType, $keepResolvers);
                 },
-                'interfaces' => static function () use ($interfaces, $resolveType) : array {
+                'interfaces' => static function () use ($interfaces, $resolveType): array {
                     return array_map(static function (InterfaceType $iface) use ($resolveType) {
                         return $resolveType($iface);
                     }, $interfaces);
@@ -62,12 +62,12 @@ class SchemaRecreation
                 'name' => $type->name,
                 'description' => $type->description,
                 'astNode' => $type->astNode,
-                'fields' => static function () use ($fields, $resolveType, $keepResolvers) : array {
+                'fields' => static function () use ($fields, $resolveType, $keepResolvers): array {
                     return static::fieldMapToFieldConfigMap($fields, $resolveType, $keepResolvers);
                 },
                 'resolveType' => $keepResolvers
                     ? $type->config['resolveType']
-                    : static function ($parent, $context, ResolveInfo $info) : Type {
+                    : static function ($parent, $context, ResolveInfo $info): Type {
                         return ResolveFromParentTypename::invoke($parent, $info->schema);
                     },
             ]);
@@ -78,14 +78,14 @@ class SchemaRecreation
                 'name' => $type->name,
                 'description' => $type->description,
                 'astNode' => $type->astNode,
-                'types' => static function () use ($type, $resolveType) : array {
+                'types' => static function () use ($type, $resolveType): array {
                     return array_map(static function (ObjectType $unionMember) use ($resolveType) {
                         return $resolveType($unionMember);
                     }, $type->getTypes());
                 },
                 'resolveType' => $keepResolvers
                     ? $type->config['resolveType']
-                    : static function ($parent, $context, ResolveInfo $info) : Type {
+                    : static function ($parent, $context, ResolveInfo $info): Type {
                         return ResolveFromParentTypename::invoke($parent, $info->schema);
                     },
             ]);
@@ -96,7 +96,7 @@ class SchemaRecreation
                 'name' => $type->name,
                 'description' => $type->description,
                 'astNode' => $type->astNode,
-                'fields' => static function () use ($type, $resolveType) : array {
+                'fields' => static function () use ($type, $resolveType): array {
                     return static::inputFieldMapToFieldConfigMap($type->getFields(), $resolveType);
                 },
             ]);
@@ -143,31 +143,34 @@ class SchemaRecreation
             ]);
         }
 
-        throw new Error('Invalid type ' . get_class($type));
+        throw new Error('Invalid type ' . $type::class);
     }
 
-    /**
-     * @return mixed[]|float|string|null
-     */
-    protected static function parseLiteral(ValueNode $ast)
+    /** @return mixed[]|float|string|null */
+    protected static function parseLiteral(ValueNode $ast): array|float|string|null
     {
         switch (true) {
             case $ast instanceof StringValueNode:
             case $ast instanceof BooleanValueNode:
                 return $ast->value;
+
             case $ast instanceof IntValueNode:
             case $ast instanceof FloatValueNode:
                 return (float) $ast->value;
+
             case $ast instanceof ObjectValueNode:
                 $value = [];
                 foreach ($ast->fields as $field) {
                     $value[$field->name->value] = static::parseLiteral($field->value);
                 }
+
                 return $value;
+
             case $ast instanceof ListValueNode:
                 return array_map(static function (ValueNode $ast) {
                     return static::parseLiteral($ast);
                 }, $ast->values);
+
             default:
                 return null;
         }
@@ -178,7 +181,7 @@ class SchemaRecreation
      *
      * @return mixed[]
      */
-    public static function fieldMapToFieldConfigMap(array $fields, callable $resolveType, bool $keepResolvers) : array
+    public static function fieldMapToFieldConfigMap(array $fields, callable $resolveType, bool $keepResolvers): array
     {
         $result = [];
         foreach ($fields as $name => $field) {
@@ -191,14 +194,14 @@ class SchemaRecreation
             $result[$name] = static::fieldToFieldConfig(
                 $field,
                 $resolveType,
-                $keepResolvers
+                $keepResolvers,
             );
         }
 
         return $result;
     }
 
-    public static function createResolveType(callable $getType) : callable
+    public static function createResolveType(callable $getType): callable
     {
         $resolveType = static function (Type $type) use ($getType, &$resolveType) {
             if ($type instanceof ListOfType) {
@@ -229,14 +232,12 @@ class SchemaRecreation
         return $resolveType;
     }
 
-    /**
-     * @return mixed[]
-     */
+    /** @return mixed[] */
     public static function fieldToFieldConfig(
         FieldDefinition $field,
         callable $resolveType,
-        bool $keepResolvers
-    ) : array {
+        bool $keepResolvers,
+    ): array {
         return [
             'type' => $resolveType($field->getType()),
             'args' => static::argsToFieldConfigArgumentMap($field->args, $resolveType),
@@ -254,7 +255,7 @@ class SchemaRecreation
      *
      * @return mixed[]
      */
-    public static function argsToFieldConfigArgumentMap(array $args, callable $resolveType) : array
+    public static function argsToFieldConfigArgumentMap(array $args, callable $resolveType): array
     {
         $result = [];
         foreach ($args as $arg) {
@@ -269,10 +270,8 @@ class SchemaRecreation
         return $result;
     }
 
-    /**
-     * @return mixed[]|null
-     */
-    public static function argumentToArgumentConfig(FieldArgument $argument, callable $resolveType) : ?array
+    /** @return mixed[]|null */
+    public static function argumentToArgumentConfig(FieldArgument $argument, callable $resolveType): array|null
     {
         $type = $resolveType($argument->getType());
         if ($type === null) {
@@ -288,7 +287,7 @@ class SchemaRecreation
             $config['defaultValue'] = $argument->defaultValue;
         }
 
-        return [ $argument->name, $config ];
+        return [$argument->name, $config];
     }
 
     /**
@@ -296,7 +295,7 @@ class SchemaRecreation
      *
      * @return mixed[]
      */
-    public static function inputFieldMapToFieldConfigMap(array $fields, callable $resolveType) : array
+    public static function inputFieldMapToFieldConfigMap(array $fields, callable $resolveType): array
     {
         $result = [];
         foreach ($fields as $name => $field) {
@@ -311,10 +310,8 @@ class SchemaRecreation
         return $result;
     }
 
-    /**
-     * @return mixed[]
-     */
-    public static function inputFieldToFieldConfig(InputObjectField $field, callable $resolveType) : array
+    /** @return mixed[] */
+    public static function inputFieldToFieldConfig(InputObjectField $field, callable $resolveType): array
     {
         $config = [
             'type' => $resolveType($field->getType()),

--- a/src/Stitching/SchemaRecreation.php
+++ b/src/Stitching/SchemaRecreation.php
@@ -12,9 +12,9 @@ use GraphQL\Language\AST\ListValueNode;
 use GraphQL\Language\AST\ObjectValueNode;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Language\AST\ValueNode;
+use GraphQL\Type\Definition\Argument;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\EnumType;
-use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InputObjectField;
 use GraphQL\Type\Definition\InputObjectType;
@@ -205,7 +205,7 @@ class SchemaRecreation
     {
         $resolveType = static function (Type $type) use ($getType, &$resolveType) {
             if ($type instanceof ListOfType) {
-                $innerType = $resolveType($type->ofType);
+                $innerType = $resolveType($type->getWrappedType());
                 if ($innerType === null) {
                     return null;
                 }
@@ -246,12 +246,12 @@ class SchemaRecreation
             'description' => $field->description,
             'deprecationReason' => $field->deprecationReason,
             'astNode' => $field->astNode,
-            'complexity' => $field->getComplexityFn(),
+            'complexity' => $field->complexityFn,
         ];
     }
 
     /**
-     * @param FieldArgument[] $args
+     * @param Argument[] $args
      *
      * @return mixed[]
      */
@@ -271,7 +271,7 @@ class SchemaRecreation
     }
 
     /** @return mixed[]|null */
-    public static function argumentToArgumentConfig(FieldArgument $argument, callable $resolveType): array|null
+    public static function argumentToArgumentConfig(Argument $argument, callable $resolveType): array|null
     {
         $type = $resolveType($argument->getType());
         if ($type === null) {

--- a/src/Stitching/SchemaRecreation.php
+++ b/src/Stitching/SchemaRecreation.php
@@ -245,6 +245,7 @@ class SchemaRecreation
             'description' => $field->description,
             'deprecationReason' => $field->deprecationReason,
             'astNode' => $field->astNode,
+            'complexity' => $field->getComplexityFn(),
         ];
     }
 

--- a/src/Stitching/TypeFromAST.php
+++ b/src/Stitching/TypeFromAST.php
@@ -74,7 +74,7 @@ class TypeFromAST
             'interfaces' => static function () use ($node) {
                 return array_map(static function (NamedTypeNode $iface) {
                     return static::createNamedStub($iface->name->value, 'interface');
-                }, $node->interfaces);
+                }, Utils::toArray($node->interfaces));
             },
             'description' => Utils::getDescription($node, static::$backcompatOptions),
         ]);
@@ -117,7 +117,7 @@ class TypeFromAST
             'types' => static function () use ($node) {
                 return array_map(static function (NamedTypeNode $type) {
                     return static::resolveType($type, 'object');
-                }, $node->types);
+                }, Utils::toArray($node->types));
             },
             'description' => Utils::getDescription($node, static::$backcompatOptions),
             'resolveType' => static function ($parent, $context, $info) {
@@ -148,7 +148,7 @@ class TypeFromAST
         return new InputObjectType([
             'name' => $node->name->value,
             'fields' => static function () use ($node) {
-                return static::makeValues($node->fields);
+                return static::makeValues(Utils::toArray($node->fields));
             },
             'description' => Utils::getDescription($node, static::$backcompatOptions),
         ]);

--- a/src/Transforms/AddArgumentsAsVariables.php
+++ b/src/Transforms/AddArgumentsAsVariables.php
@@ -13,6 +13,7 @@ use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\ListTypeNode;
 use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Language\AST\NameNode;
+use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\NonNullTypeNode;
 use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Language\AST\SelectionNode;
@@ -22,7 +23,6 @@ use GraphQL\Language\AST\VariableDefinitionNode;
 use GraphQL\Language\AST\VariableNode;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Schema;
 use GraphQLTools\Utils;
 
@@ -31,7 +31,6 @@ use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_values;
-use function assert;
 use function in_array;
 use function sprintf;
 
@@ -92,7 +91,6 @@ class AddArgumentsAsVariables implements Transform
                     &$variableCounter,
                     $existingVariables,
                 ): string {
-                    $varName = null;
                     do {
                         $varName = sprintf('_v%s_%s', $variableCounter, $argName);
                         $variableCounter++;
@@ -101,8 +99,6 @@ class AddArgumentsAsVariables implements Transform
                     return $varName;
                 };
 
-                $type = null;
-                assert($type instanceof ObjectType);
                 if ($operation->operation === 'subscription') {
                     $type = $targetSchema->getSubscriptionType();
                 } elseif ($operation->operation === 'mutation') {
@@ -160,7 +156,7 @@ class AddArgumentsAsVariables implements Transform
                     Utils::toArray($operation->variableDefinitions),
                     array_values($variables),
                 );
-                $operation->selectionSet        = new SelectionSetNode(['selections' => $newSelectionSet]);
+                $operation->selectionSet        = new SelectionSetNode(['selections' => NodeList::create($newSelectionSet)]);
 
                 return $operation;
             },

--- a/src/Transforms/AddArgumentsAsVariables.php
+++ b/src/Transforms/AddArgumentsAsVariables.php
@@ -69,10 +69,10 @@ class AddArgumentsAsVariables implements Transform
      */
     private static function addVariablesToRootField(Schema $targetSchema, DocumentNode $document, array $args): array
     {
-        $operations = array_filter($document->definitions, static function (DefinitionNode $def) {
+        $operations = array_filter(Utils::toArray($document->definitions), static function (DefinitionNode $def) {
             return $def instanceof OperationDefinitionNode;
         });
-        $fragments  = array_filter($document->definitions, static function (DefinitionNode $def) {
+        $fragments  = array_filter(Utils::toArray($document->definitions), static function (DefinitionNode $def) {
             return $def instanceof FragmentDefinitionNode;
         });
 
@@ -144,7 +144,7 @@ class AddArgumentsAsVariables implements Transform
                         }
 
                         $selection            = clone$selection;
-                        $selection->arguments = array_values($newArgs);
+                        $selection->arguments = new NodeList(array_values($newArgs));
                         $newSelectionSet[]    = $selection;
                     } else {
                         $newSelectionSet[] = $selection;
@@ -152,11 +152,11 @@ class AddArgumentsAsVariables implements Transform
                 }
 
                 $operation                      = clone$operation;
-                $operation->variableDefinitions = array_merge(
+                $operation->variableDefinitions = new NodeList(array_merge(
                     Utils::toArray($operation->variableDefinitions),
                     array_values($variables),
-                );
-                $operation->selectionSet        = new SelectionSetNode(['selections' => NodeList::create($newSelectionSet)]);
+                ));
+                $operation->selectionSet        = new SelectionSetNode(['selections' => new NodeList($newSelectionSet)]);
 
                 return $operation;
             },
@@ -169,7 +169,7 @@ class AddArgumentsAsVariables implements Transform
         }
 
         $document              = clone$document;
-        $document->definitions = array_merge($newOperations, $fragments);
+        $document->definitions = new NodeList(array_merge($newOperations, $fragments));
 
         return [
             'document' => $document,
@@ -190,7 +190,7 @@ class AddArgumentsAsVariables implements Transform
 
         if ($type instanceof ListTypeNode) {
             return new ListTypeNode([
-                'type' => static::typeToAst($type->ofType),
+                'type' => static::typeToAst($type->type),
             ]);
         }
 

--- a/src/Transforms/AddTypenameToAbstract.php
+++ b/src/Transforms/AddTypenameToAbstract.php
@@ -78,7 +78,7 @@ class AddTypenameToAbstract implements Transform
 
                         if ($newSelections !== $selections) {
                             $transformedNode             = clone$node;
-                            $transformedNode->selections = NodeList::create($newSelections);
+                            $transformedNode->selections = new NodeList($newSelections);
 
                             return $transformedNode;
                         }

--- a/src/Transforms/AddTypenameToAbstract.php
+++ b/src/Transforms/AddTypenameToAbstract.php
@@ -16,18 +16,15 @@ use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\TypeInfo;
 use GraphQLTools\Utils;
+
 use function array_filter;
 use function array_merge;
 use function count;
 
 class AddTypenameToAbstract implements Transform
 {
-    /** @var Schema */
-    private $targetSchema;
-
-    public function __construct(Schema $targetSchema)
+    public function __construct(private Schema $targetSchema)
     {
-        $this->targetSchema = $targetSchema;
     }
 
     /**
@@ -35,16 +32,17 @@ class AddTypenameToAbstract implements Transform
      *
      * @return mixed[]
      */
-    public function transformRequest(array $originalRequest) : array
+    public function transformRequest(array $originalRequest): array
     {
         $document = $this->addTypenameToAbstract($this->targetSchema, $originalRequest['document']);
+
         return array_merge(
             $originalRequest,
-            ['document' => $document]
+            ['document' => $document],
         );
     }
 
-    private function addTypenameToAbstract(Schema $targetSchema, DocumentNode $document) : DocumentNode
+    private function addTypenameToAbstract(Schema $targetSchema, DocumentNode $document): DocumentNode
     {
         $typeInfo = new TypeInfo($targetSchema);
 
@@ -63,10 +61,11 @@ class AddTypenameToAbstract implements Transform
                                 static function (SelectionNode $selectionNode) {
                                     return $selectionNode instanceof FieldNode
                                         && $selectionNode->name->value === '__typename';
-                                }
-                            )
+                                },
+                            ),
                         ) > 0;
-                        if ($parentType
+                        if (
+                            $parentType
                             && ($parentType instanceof InterfaceType || $parentType instanceof UnionType)
                             && ! $typenameFound
                         ) {
@@ -74,16 +73,18 @@ class AddTypenameToAbstract implements Transform
                                 'name' => new NameNode(['value' => '__typename']),
                             ]);
                         }
+
                         if ($selections !== $node->selections) {
                             $transformedNode             = clone$node;
                             $transformedNode->selections = $selections;
+
                             return $transformedNode;
                         }
 
                         return null;
                     },
-                ]
-            )
+                ],
+            ),
         );
     }
 }

--- a/src/Transforms/CheckResultAndHandleErrors.php
+++ b/src/Transforms/CheckResultAndHandleErrors.php
@@ -10,22 +10,14 @@ use GraphQLTools\Stitching\Errors;
 
 class CheckResultAndHandleErrors implements Transform
 {
-    /** @var ResolveInfo */
-    private $info;
+    private string $fieldName;
 
-    /** @var string */
-    private $fieldName;
-
-    public function __construct(ResolveInfo $info, ?string $fieldName = null)
+    public function __construct(private ResolveInfo $info, string|null $fieldName = null)
     {
-        $this->info      = $info;
         $this->fieldName = $fieldName;
     }
 
-    /**
-     * @return mixed
-     */
-    public function transformResult(ExecutionResult $result)
+    public function transformResult(ExecutionResult $result): mixed
     {
         return Errors::checkResultAndHandleErrors($result, $this->info, $this->fieldName);
     }

--- a/src/Transforms/ComposeTransforms.php
+++ b/src/Transforms/ComposeTransforms.php
@@ -9,18 +9,12 @@ use GraphQL\Type\Schema;
 
 class ComposeTransforms implements Transform
 {
-    /** @var Transform[] */
-    private $transforms;
-
-    /**
-     * @param Transform[] $transforms
-     */
-    public function __construct(array $transforms)
+    /** @param Transform[] $transforms */
+    public function __construct(private array $transforms)
     {
-        $this->transforms = $transforms;
     }
 
-    public function transformSchema(Schema $schema) : Schema
+    public function transformSchema(Schema $schema): Schema
     {
         return Transforms::applySchemaTransforms($schema, $this->transforms);
     }
@@ -30,12 +24,12 @@ class ComposeTransforms implements Transform
      *
      * @return mixed[]
      */
-    public function transformRequest(array $originalRequest) : array
+    public function transformRequest(array $originalRequest): array
     {
         return Transforms::applyRequestTransforms($originalRequest, $this->transforms);
     }
 
-    public function transformResult(ExecutionResult $result) : ExecutionResult
+    public function transformResult(ExecutionResult $result): ExecutionResult
     {
         return Transforms::applyResultTransform($result, $this->transforms);
     }

--- a/src/Transforms/ConvertEnumResponse.php
+++ b/src/Transforms/ConvertEnumResponse.php
@@ -9,15 +9,14 @@ use GraphQL\Type\Definition\EnumType;
 
 class ConvertEnumResponse implements Transform
 {
-    /** @var EnumType */
-    private $enumNode;
+    private EnumType $enumNode;
 
     public function __construct(EnumType $enumType)
     {
         $this->enumNode = $enumType;
     }
 
-    public function transformResult(ExecutionResult $result) : ExecutionResult
+    public function transformResult(ExecutionResult $result): ExecutionResult
     {
         $value = $this->enumNode->getValue($result);
         if ($value) {

--- a/src/Transforms/ConvertEnumValues.php
+++ b/src/Transforms/ConvertEnumValues.php
@@ -6,22 +6,17 @@ namespace GraphQLTools\Transforms;
 
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Schema;
+
 use function count;
 
 class ConvertEnumValues implements Transform
 {
-    /** @var mixed[]|null */
-    private $enumValueMap;
-
-    /**
-     * @param mixed[]|null $enumValueMap
-     */
-    public function __construct(?array $enumValueMap = null)
+    /** @param mixed[]|null $enumValueMap */
+    public function __construct(private array|null $enumValueMap = null)
     {
-        $this->enumValueMap = $enumValueMap;
     }
 
-    public function transformSchema(Schema $schema) : Schema
+    public function transformSchema(Schema $schema): Schema
     {
         $enumValueMap = $this->enumValueMap;
         if (! $enumValueMap || count($enumValueMap) === 0) {

--- a/src/Transforms/ExpandAbstractTypes.php
+++ b/src/Transforms/ExpandAbstractTypes.php
@@ -14,6 +14,7 @@ use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Language\AST\NameNode;
 use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Language\AST\SelectionSetNode;
 use GraphQL\Language\Visitor;
@@ -200,7 +201,7 @@ class ExpandAbstractTypes implements Transform
                         $fragmentReplacements,
                         $reverseMapping,
                     ): SelectionSetNode|null {
-                        $newSelections = $node->selections;
+                        $newSelections = Utils::toArray($node->selections);
                         $parentType    = Type::getNamedType($typeInfo->getParentType());
 
                         foreach ($node->selections as $selection) {
@@ -260,7 +261,7 @@ class ExpandAbstractTypes implements Transform
 
                         if (count($newSelections) !== count($node->selections)) {
                             $node             = clone$node;
-                            $node->selections = $newSelections;
+                            $node->selections = NodeList::create($newSelections);
 
                             return $node;
                         }

--- a/src/Transforms/ExpandAbstractTypes.php
+++ b/src/Transforms/ExpandAbstractTypes.php
@@ -132,11 +132,11 @@ class ExpandAbstractTypes implements Transform
         array $reverseMapping,
         DocumentNode $document,
     ): DocumentNode {
-        $operations = array_filter($document->definitions, static function (DefinitionNode $def) {
+        $operations = array_filter(Utils::toArray($document->definitions), static function (DefinitionNode $def) {
             return $def instanceof OperationDefinitionNode;
         });
         /** @var FragmentDefinitionNode[] $fragments */
-        $fragments = array_filter($document->definitions, static function (DefinitionNode $def) {
+        $fragments = array_filter(Utils::toArray($document->definitions), static function (DefinitionNode $def) {
             return $def instanceof FragmentDefinitionNode;
         });
 
@@ -185,7 +185,7 @@ class ExpandAbstractTypes implements Transform
         }
 
         $newDocument              = clone$document;
-        $newDocument->definitions = array_merge($operations, $newFragments);
+        $newDocument->definitions = new NodeList(array_merge($operations, $newFragments));
 
         $typeInfo = new TypeInfo($targetSchema);
 
@@ -261,7 +261,7 @@ class ExpandAbstractTypes implements Transform
 
                         if (count($newSelections) !== count($node->selections)) {
                             $node             = clone$node;
-                            $node->selections = NodeList::create($newSelections);
+                            $node->selections = new NodeList($newSelections);
 
                             return $node;
                         }

--- a/src/Transforms/ExtractField.php
+++ b/src/Transforms/ExtractField.php
@@ -8,19 +8,18 @@ use GraphQL\Language\AST\FieldNode;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\Visitor;
 use GraphQL\Language\VisitorOperation;
+
 use function array_pop;
 use function json_encode;
 
 class ExtractField implements Transform
 {
     /** @var string[]  */
-    private $from;
+    private array $from;
     /** @var string[] */
-    private $to;
+    private array $to;
 
-    /**
-     * @param string[][] $options
-     */
+    /** @param string[][] $options */
     public function __construct(array $options)
     {
         $this->from = $options['from'];
@@ -32,7 +31,7 @@ class ExtractField implements Transform
      *
      * @return mixed[]
      */
-    public function transformRequest(array $originalRequest) : array
+    public function transformRequest(array $originalRequest): array
     {
         $fromSelection = null;
         $ourPathFrom   = json_encode($this->from);
@@ -50,16 +49,17 @@ class ExtractField implements Transform
 
                             $o          = new VisitorOperation();
                             $o->doBreak = true;
+
                             return $o;
                         }
 
                         return null;
                     },
-                    'leave' => static function (FieldNode $node) use (&$fieldPath) : void {
+                    'leave' => static function (FieldNode $node) use (&$fieldPath): void {
                         array_pop($fieldPath);
                     },
                 ],
-            ]
+            ],
         );
 
         $fieldPath   = [];
@@ -73,18 +73,21 @@ class ExtractField implements Transform
                         if ($ourPathTo === json_encode($fieldPath) && isset($fromSelection)) {
                             $node               = clone$node;
                             $node->selectionSet = $fromSelection;
+
                             return $node;
                         }
+
                         return null;
                     },
-                    'leave' => static function (FieldNode $node) use (&$fieldPath) : void {
+                    'leave' => static function (FieldNode $node) use (&$fieldPath): void {
                         array_pop($fieldPath);
                     },
                 ],
-            ]
+            ],
         );
 
         $originalRequest['document'] = $newDocument;
+
         return $originalRequest;
     }
 }

--- a/src/Transforms/ExtractField.php
+++ b/src/Transforms/ExtractField.php
@@ -7,7 +7,7 @@ namespace GraphQLTools\Transforms;
 use GraphQL\Language\AST\FieldNode;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\Visitor;
-use GraphQL\Language\VisitorOperation;
+use GraphQL\Language\VisitorStop;
 
 use function array_pop;
 use function json_encode;
@@ -47,10 +47,7 @@ class ExtractField implements Transform
                         if ($ourPathFrom === json_encode($fieldPath)) {
                             $fromSelection = $node->selectionSet;
 
-                            $o          = new VisitorOperation();
-                            $o->doBreak = true;
-
-                            return $o;
+                            return new VisitorStop();
                         }
 
                         return null;

--- a/src/Transforms/FilterRootFields.php
+++ b/src/Transforms/FilterRootFields.php
@@ -8,8 +8,7 @@ use GraphQL\Type\Schema;
 
 class FilterRootFields implements Transform
 {
-    /** @var TransformRootFields  */
-    private $transformer;
+    private TransformRootFields $transformer;
 
     public function __construct(callable $filter)
     {
@@ -20,13 +19,14 @@ class FilterRootFields implements Transform
                 }
 
                 return false;
-            }
+            },
         );
     }
 
-    public function transformSchema(Schema $originalSchema) : Schema
+    public function transformSchema(Schema $originalSchema): Schema
     {
         $transformer = $this->transformer;
+
         return $transformer->transformSchema($originalSchema);
     }
 }

--- a/src/Transforms/FilterToSchema.php
+++ b/src/Transforms/FilterToSchema.php
@@ -181,7 +181,7 @@ class FilterToSchema implements Transform
             );
 
             $fragment = array_values($fragments)[0] ?? null;
-            assert($fragment instanceof FragmentDefinitionNode);
+            assert($fragment instanceof FragmentDefinitionNode || $fragment === null);
 
             if (! $fragment) {
                 continue;
@@ -324,8 +324,9 @@ class FilterToSchema implements Transform
                 ) {
                     if (isset($validFragments[$node->name->value])) {
                         $parentType = static::resolveType($typeStack[count($typeStack) - 1]);
+                        $innerType  = $validFragments[$node->name->value];
                         assert($parentType instanceof Type);
-                        $innerType = $validFragments[$node->name->value];
+                        assert($innerType instanceof Type);
 
                         if (! Utils::implementsAbstractType($schema, $parentType, $innerType)) {
                             return Visitor::removeNode();
@@ -346,6 +347,7 @@ class FilterToSchema implements Transform
 
                         $innerType  = $schema->getType($node->typeCondition->name->value);
                         $parentType = static::resolveType($typeStack[count($typeStack) - 1]);
+                        assert($innerType instanceof Type);
                         assert($parentType instanceof Type);
                         if (Utils::implementsAbstractType($schema, $parentType, $innerType)) {
                             $typeStack[] = $innerType;

--- a/src/Transforms/FilterTypes.php
+++ b/src/Transforms/FilterTypes.php
@@ -16,9 +16,10 @@ class FilterTypes implements Transform
         $this->filter = $filter;
     }
 
-    public function transformSchema(Schema $schema) : Schema
+    public function transformSchema(Schema $schema): Schema
     {
         $filter = $this->filter;
+
         return VisitSchema::invoke($schema, [
             VisitSchemaKind::TYPE => static function ($type) use ($filter) {
                 if ($filter($type)) {

--- a/src/Transforms/RenameRootFields.php
+++ b/src/Transforms/RenameRootFields.php
@@ -9,15 +9,14 @@ use GraphQLTools\Stitching\SchemaRecreation;
 
 class RenameRootFields implements Transform
 {
-    /** @var TransformRootFields */
-    private $transformer;
+    private TransformRootFields $transformer;
 
     public function __construct(callable $renamer)
     {
         $resolveType = SchemaRecreation::createResolveType(
             static function ($name, $type) {
                 return $type;
-            }
+            },
         );
 
         $this->transformer = new TransformRootFields(
@@ -26,11 +25,11 @@ class RenameRootFields implements Transform
                     'name' => $renamer($operation, $fieldName, $field),
                     'field' => SchemaRecreation::fieldToFieldConfig($field, $resolveType, true),
                 ];
-            }
+            },
         );
     }
 
-    public function transformSchema(Schema $originalSchema) : Schema
+    public function transformSchema(Schema $originalSchema): Schema
     {
         return $this->transformer->transformSchema($originalSchema);
     }

--- a/src/Transforms/ReplaceFieldWithFragment.php
+++ b/src/Transforms/ReplaceFieldWithFragment.php
@@ -22,32 +22,29 @@ use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\TypeInfo;
 use GraphQLTools\Utils;
+
 use function array_keys;
 use function array_merge;
 use function array_reduce;
 use function array_values;
+use function assert;
 use function count;
 use function preg_match;
 use function trim;
 
 class ReplaceFieldWithFragment implements Transform
 {
-    /** @var Schema  */
-    private $targetSchema;
     /** @var mixed[] */
-    private $mapping;
+    private array $mapping;
 
-    /**
-     * @param mixed[] $fragments
-     */
-    public function __construct(Schema $targetSchema, array $fragments)
+    /** @param mixed[] $fragments */
+    public function __construct(private Schema $targetSchema, array $fragments)
     {
-        $this->targetSchema = $targetSchema;
-        $this->mapping      = [];
+        $this->mapping = [];
         foreach ($fragments as ['field' => $field, 'fragment' => $fragment]) {
-            $parsedFragment                 = static::parseFragmentToInlineFragment($fragment);
-            $actualTypeName                 = $parsedFragment->typeCondition->name->value;
-            $this->mapping[$actualTypeName] = $this->mapping[$actualTypeName] ?? [];
+            $parsedFragment                   = static::parseFragmentToInlineFragment($fragment);
+            $actualTypeName                   = $parsedFragment->typeCondition->name->value;
+            $this->mapping[$actualTypeName] ??= [];
 
             if (isset($this->mapping[$actualTypeName][$field])) {
                 $this->mapping[$actualTypeName][$field][] = $parsedFragment;
@@ -62,35 +59,35 @@ class ReplaceFieldWithFragment implements Transform
      *
      * @return mixed[]
      */
-    public function transformRequest(array $originalRequest) : array
+    public function transformRequest(array $originalRequest): array
     {
         $document = static::replaceFieldsWithFragments(
             $this->targetSchema,
             $originalRequest['document'],
-            $this->mapping
+            $this->mapping,
         );
 
         $originalRequest['document'] = $document;
+
         return $originalRequest;
     }
 
-    /**
-     * @param mixed[] $mapping
-     */
+    /** @param mixed[] $mapping */
     private static function replaceFieldsWithFragments(
         Schema $targetSchema,
         DocumentNode $document,
-        array $mapping
-    ) : DocumentNode {
+        array $mapping,
+    ): DocumentNode {
         $typeInfo = new TypeInfo($targetSchema);
+
         return Visitor::visit(
             $document,
             Visitor::visitWithTypeInfo(
                 $typeInfo,
                 [
                     NodeKind::SELECTION_SET => static function (SelectionSetNode $node) use ($typeInfo, $mapping) {
-                        /** @var Type $parentType */
                         $parentType = $typeInfo->getParentType();
+                        assert($parentType instanceof Type);
 
                         if ($parentType) {
                             $parentTypeName = $parentType->name;
@@ -110,7 +107,7 @@ class ReplaceFieldWithFragment implements Transform
 
                                     $fragment   = static::concatInlineFragments(
                                         $parentTypeName,
-                                        $fragments
+                                        $fragments,
                                     );
                                     $selections = array_merge($selections, [$fragment]);
                                 }
@@ -119,18 +116,19 @@ class ReplaceFieldWithFragment implements Transform
                             if ($selections !== $node->selections) {
                                 $node             = clone $node;
                                 $node->selections = array_values($selections);
+
                                 return $node;
                             }
                         }
 
                         return null;
                     },
-                ]
-            )
+                ],
+            ),
         );
     }
 
-    private static function parseFragmentToInlineFragment(string $definitions) : InlineFragmentNode
+    private static function parseFragmentToInlineFragment(string $definitions): InlineFragmentNode
     {
         if (preg_match('/^fragment/', trim($definitions)) !== 0) {
             $document = Parser::parse($definitions);
@@ -144,8 +142,8 @@ class ReplaceFieldWithFragment implements Transform
             }
         }
 
-        /** @var OperationDefinitionNode $query */
         $query = Parser::parse('{' . $definitions . '}')->definitions[0];
+        assert($query instanceof OperationDefinitionNode);
 
         foreach ($query->selectionSet->selections as $selection) {
             if ($selection instanceof InlineFragmentNode) {
@@ -156,17 +154,15 @@ class ReplaceFieldWithFragment implements Transform
         throw new Error('Could not parse fragment');
     }
 
-    /**
-     * @param InlineFragmentNode[] $fragments
-     */
-    private static function concatInlineFragments(string $type, array $fragments) : InlineFragmentNode
+    /** @param InlineFragmentNode[] $fragments */
+    private static function concatInlineFragments(string $type, array $fragments): InlineFragmentNode
     {
         $fragmentSelections = array_reduce(
             $fragments,
             static function (array $selections, InlineFragmentNode $fragment) {
                 return array_merge($selections, Utils::toArray($fragment->selectionSet->selections));
             },
-            []
+            [],
         );
 
         $deduplicatedFragmentSelection = static::deduplicateSelection($fragmentSelections);
@@ -184,7 +180,7 @@ class ReplaceFieldWithFragment implements Transform
      *
      * @return SelectionNode[]
      */
-    private static function deduplicateSelection(array $nodes) : array
+    private static function deduplicateSelection(array $nodes): array
     {
         $selectionMap = array_reduce(
             $nodes,
@@ -196,6 +192,7 @@ class ReplaceFieldWithFragment implements Transform
                         }
 
                         $map[$node->alias->value] = $node;
+
                         return $map;
                     }
 
@@ -204,35 +201,42 @@ class ReplaceFieldWithFragment implements Transform
                     }
 
                     $map[$node->name->value] = $node;
+
                     return $map;
-                } elseif ($node instanceof FragmentSpreadNode) {
+                }
+
+                if ($node instanceof FragmentSpreadNode) {
                     if (isset($map[$node->name->value])) {
                         return $map;
                     }
 
                     $map[$node->name->value] = $node;
+
                     return $map;
-                } elseif ($node instanceof InlineFragmentNode) {
+                }
+
+                if ($node instanceof InlineFragmentNode) {
                     if (! isset($map['__fragment'])) {
                         $map['__fragment'] = $node;
+
                         return $map;
                     }
 
-                    /** @var InlineFragmentNode $fragment */
                     $fragment = $map['__fragment'];
+                    assert($fragment instanceof InlineFragmentNode);
 
                     $map['__fragment'] = static::concatInlineFragments(
                         $fragment->typeCondition->name->value,
                         [
                             $fragment,
                             $node,
-                        ]
+                        ],
                     );
                 }
 
                 return $map;
             },
-            []
+            [],
         );
 
         return array_reduce(
@@ -240,7 +244,7 @@ class ReplaceFieldWithFragment implements Transform
             static function (array $selectionList, $node) use ($selectionMap) {
                 return array_merge($selectionList, [$selectionMap[$node]]);
             },
-            []
+            [],
         );
     }
 }

--- a/src/Transforms/ReplaceFieldWithFragment.php
+++ b/src/Transforms/ReplaceFieldWithFragment.php
@@ -13,12 +13,12 @@ use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\NamedTypeNode;
 use GraphQL\Language\AST\NameNode;
 use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Language\AST\SelectionNode;
 use GraphQL\Language\AST\SelectionSetNode;
 use GraphQL\Language\Parser;
 use GraphQL\Language\Visitor;
-use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\TypeInfo;
 use GraphQLTools\Utils;
@@ -87,7 +87,6 @@ class ReplaceFieldWithFragment implements Transform
                 [
                     NodeKind::SELECTION_SET => static function (SelectionSetNode $node) use ($typeInfo, $mapping) {
                         $parentType = $typeInfo->getParentType();
-                        assert($parentType instanceof Type);
 
                         if ($parentType) {
                             $parentTypeName = $parentType->name;
@@ -113,9 +112,9 @@ class ReplaceFieldWithFragment implements Transform
                                 }
                             }
 
-                            if ($selections !== $node->selections) {
+                            if (count($selections) !== count($node->selections)) {
                                 $node             = clone $node;
-                                $node->selections = array_values($selections);
+                                $node->selections = NodeList::create(array_values($selections));
 
                                 return $node;
                             }
@@ -171,7 +170,7 @@ class ReplaceFieldWithFragment implements Transform
             'typeCondition' => new NamedTypeNode([
                 'name' => new NameNode(['value' => $type]),
             ]),
-            'selectionSet' => new SelectionSetNode(['selections' => $deduplicatedFragmentSelection]),
+            'selectionSet' => new SelectionSetNode(['selections' => NodeList::create($deduplicatedFragmentSelection)]),
         ]);
     }
 

--- a/src/Transforms/ReplaceFieldWithFragment.php
+++ b/src/Transforms/ReplaceFieldWithFragment.php
@@ -114,7 +114,7 @@ class ReplaceFieldWithFragment implements Transform
 
                             if (count($selections) !== count($node->selections)) {
                                 $node             = clone $node;
-                                $node->selections = NodeList::create(array_values($selections));
+                                $node->selections = new NodeList(array_values($selections));
 
                                 return $node;
                             }
@@ -170,7 +170,7 @@ class ReplaceFieldWithFragment implements Transform
             'typeCondition' => new NamedTypeNode([
                 'name' => new NameNode(['value' => $type]),
             ]),
-            'selectionSet' => new SelectionSetNode(['selections' => NodeList::create($deduplicatedFragmentSelection)]),
+            'selectionSet' => new SelectionSetNode(['selections' => new NodeList($deduplicatedFragmentSelection)]),
         ]);
     }
 

--- a/src/Transforms/TransformRootFields.php
+++ b/src/Transforms/TransformRootFields.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Schema;
 use GraphQLTools\Stitching\SchemaRecreation;
+
 use function count;
 
 class TransformRootFields implements Transform
@@ -20,7 +21,7 @@ class TransformRootFields implements Transform
         $this->transform = $transform;
     }
 
-    public function transformSchema(Schema $originalSchema) : Schema
+    public function transformSchema(Schema $originalSchema): Schema
     {
         return VisitSchema::invoke(
             $originalSchema,
@@ -28,31 +29,34 @@ class TransformRootFields implements Transform
                 VisitSchemaKind::QUERY => function (ObjectType $type) {
                     return static::transformFields($type, function ($fieldName, $field) {
                         $transform = $this->transform;
+
                         return $transform('Query', $fieldName, $field);
                     });
                 },
                 VisitSchemaKind::MUTATION => function (ObjectType $type) {
                     return static::transformFields($type, function ($fieldName, $field) {
                         $transform = $this->transform;
+
                         return $transform('Mutation', $fieldName, $field);
                     });
                 },
                 VisitSchemaKind::SUBSCRIPTION => function (ObjectType $type) {
                     return static::transformFields($type, function ($fieldName, $field) {
                         $transform = $this->transform;
+
                         return $transform('Subscription', $fieldName, $field);
                     });
                 },
-            ]
+            ],
         );
     }
 
-    private static function transformFields(ObjectType $type, callable $transformer) : ?ObjectType
+    private static function transformFields(ObjectType $type, callable $transformer): ObjectType|null
     {
         $resolveType = SchemaRecreation::createResolveType(
             static function (string $name, NamedType $originalType) {
                 return $originalType;
-            }
+            },
         );
         $fields      = $type->getFields();
         $newFields   = [];

--- a/src/Transforms/TransformRootFields.php
+++ b/src/Transforms/TransformRootFields.php
@@ -68,7 +68,7 @@ class TransformRootFields implements Transform
             } elseif ($newField !== false) {
                 $newFields[$newField['name']] = $newField['field'];
             } else {
-                unset($newField[$fieldName]);
+                unset($newFields[$fieldName]);
             }
         }
 

--- a/src/Transforms/TransformSchema.php
+++ b/src/Transforms/TransformSchema.php
@@ -10,10 +10,8 @@ use GraphQLTools\Stitching\Resolvers;
 
 class TransformSchema
 {
-    /**
-     * @param Transform[] $transforms
-     */
-    public static function invoke(Schema $targetSchema, array $transforms) : Schema
+    /** @param Transform[] $transforms */
+    public static function invoke(Schema $targetSchema, array $transforms): Schema
     {
         $schema    = VisitSchema::invoke($targetSchema, [], true);
         $mapping   = Resolvers::generateSimpleMapping($targetSchema);
@@ -21,11 +19,12 @@ class TransformSchema
         $schema    = MakeExecutableSchema::addResolveFunctionsToSchema(
             $schema,
             $resolvers,
-            ['allowResolversNotInSchema' => true]
+            ['allowResolversNotInSchema' => true],
         );
 
         $schema             = Transforms::applySchemaTransforms($schema, $transforms);
         $schema->transforms = $transforms;
+
         return $schema;
     }
 }

--- a/src/Transforms/Transforms.php
+++ b/src/Transforms/Transforms.php
@@ -6,16 +6,15 @@ namespace GraphQLTools\Transforms;
 
 use GraphQL\Executor\ExecutionResult;
 use GraphQL\Type\Schema;
+
 use function array_reduce;
 use function array_reverse;
 use function is_callable;
 
 class Transforms
 {
-    /**
-     * @param Transform[] $transforms
-     */
-    public static function applySchemaTransforms(Schema $originalSchema, array $transforms) : Schema
+    /** @param Transform[] $transforms */
+    public static function applySchemaTransforms(Schema $originalSchema, array $transforms): Schema
     {
         return array_reduce($transforms, static function (Schema $schema, Transform $transform) {
             return is_callable([$transform, 'transformSchema']) ? $transform->transformSchema($schema) : $schema;
@@ -28,31 +27,26 @@ class Transforms
      *
      * @return mixed[]
      */
-    public static function applyRequestTransforms(array $originalRequest, array $transforms) : array
+    public static function applyRequestTransforms(array $originalRequest, array $transforms): array
     {
         return array_reduce($transforms, static function ($request, Transform $transform) {
             return is_callable([$transform, 'transformRequest']) ? $transform->transformRequest($request) : $request;
         }, $originalRequest);
     }
 
-    /**
-     * @param Transform[] $transforms
-     *
-     * @return mixed
-     */
-    public static function applyResultTransform(ExecutionResult $originalResult, array $transforms)
+    /** @param Transform[] $transforms */
+    public static function applyResultTransform(ExecutionResult $originalResult, array $transforms): mixed
     {
         return array_reduce($transforms, static function ($result, Transform $transform) {
             return is_callable([$transform, 'transformResult']) ? $transform->transformResult($result) : $result;
         }, $originalResult);
     }
 
-    /**
-     * @param Transform[] $transforms
-     */
-    public static function composeTransforms(array $transforms) : Transform
+    /** @param Transform[] $transforms */
+    public static function composeTransforms(array $transforms): Transform
     {
         $reverseTransforms = array_reverse($transforms);
+
         return new ComposeTransforms($reverseTransforms);
     }
 }

--- a/src/Transforms/VisitSchema.php
+++ b/src/Transforms/VisitSchema.php
@@ -16,6 +16,7 @@ use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Schema;
 use GraphQLTools\Stitching\SchemaRecreation;
+
 use function array_filter;
 use function array_key_exists;
 use function array_pop;
@@ -27,10 +28,8 @@ use function substr;
 
 class VisitSchema
 {
-    /**
-     * @param callable[] $visitor
-     */
-    public static function invoke(Schema $schema, array $visitor, bool $stripResolvers = false) : Schema
+    /** @param callable[] $visitor */
+    public static function invoke(Schema $schema, array $visitor, bool $stripResolvers = false): Schema
     {
         $types       = [];
         $resolveType = SchemaRecreation::createResolveType(static function (string $name) use (&$types) {
@@ -85,10 +84,8 @@ class VisitSchema
         ]);
     }
 
-    /**
-     * @return callable[]
-     */
-    protected static function getTypeSpecifiers(Type $type, Schema $schema) : array
+    /** @return callable[] */
+    protected static function getTypeSpecifiers(Type $type, Schema $schema): array
     {
         $specifiers = [VisitSchemaKind::TYPE];
         if ($type instanceof ObjectType) {
@@ -112,14 +109,14 @@ class VisitSchema
                 $specifiers,
                 VisitSchemaKind::COMPOSITE_TYPE,
                 VisitSchemaKind::ABSTRACT_TYPE,
-                VisitSchemaKind::INPUT_OBJECT_TYPE
+                VisitSchemaKind::INPUT_OBJECT_TYPE,
             );
         } elseif ($type instanceof UnionType) {
             array_push(
                 $specifiers,
                 VisitSchemaKind::COMPOSITE_TYPE,
                 VisitSchemaKind::ABSTRACT_TYPE,
-                VisitSchemaKind::UNION_TYPE
+                VisitSchemaKind::UNION_TYPE,
             );
         } elseif ($type instanceof EnumType) {
             $specifiers[] = VisitSchemaKind::ENUM_TYPE;
@@ -134,7 +131,7 @@ class VisitSchema
      * @param mixed[] $visitor
      * @param mixed[] $specifiers
      */
-    public static function getVisitor(array $visitor, array $specifiers) : ?callable
+    public static function getVisitor(array $visitor, array $specifiers): callable|null
     {
         $typeVisitor = null;
         $stack       = $specifiers;
@@ -146,17 +143,19 @@ class VisitSchema
         return $typeVisitor;
     }
 
-    public static function skipNode() : VisitorOperation
+    public static function skipNode(): VisitorOperation
     {
         $r             = new VisitorOperation();
         $r->doContinue = true;
+
         return $r;
     }
 
-    public static function removeNode() : VisitorOperation
+    public static function removeNode(): VisitorOperation
     {
         $r             = new VisitorOperation();
         $r->removeNode = true;
+
         return $r;
     }
 }

--- a/src/Transforms/VisitSchema.php
+++ b/src/Transforms/VisitSchema.php
@@ -6,6 +6,8 @@ namespace GraphQLTools\Transforms;
 
 use GraphQL\Error\Error;
 use GraphQL\Language\VisitorOperation;
+use GraphQL\Language\VisitorRemoveNode;
+use GraphQL\Language\VisitorSkipNode;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
@@ -59,9 +61,9 @@ class VisitSchema
                 if ($result === null) {
                     $types[$typeName] = SchemaRecreation::recreateType($type, $resolveType, ! $stripResolvers);
                 } elseif ($result instanceof VisitorOperation) {
-                    if ($result->doContinue) {
+                    if ($result instanceof VisitorSkipNode) {
                         $types[$typeName] = SchemaRecreation::recreateType($type, $resolveType, ! $stripResolvers);
-                    } elseif ($result->removeNode) {
+                    } elseif ($result instanceof VisitorRemoveNode) {
                         $types[$typeName] = null;
                     }
                 } else {
@@ -145,17 +147,11 @@ class VisitSchema
 
     public static function skipNode(): VisitorOperation
     {
-        $r             = new VisitorOperation();
-        $r->doContinue = true;
-
-        return $r;
+        return new VisitorSkipNode();
     }
 
     public static function removeNode(): VisitorOperation
     {
-        $r             = new VisitorOperation();
-        $r->removeNode = true;
-
-        return $r;
+        return new VisitorRemoveNode();
     }
 }

--- a/src/Transforms/WrapQuery.php
+++ b/src/Transforms/WrapQuery.php
@@ -58,7 +58,7 @@ class WrapQuery implements Transform
                                 || (is_array($wrapResult) && $wrapResult['kind'] === NodeKind::SELECTION_SET)
                                 ? $wrapResult
                                 : new SelectionSetNode([
-                                    'selections' => NodeList::create([$wrapResult]),
+                                    'selections' => new NodeList([$wrapResult]),
                                 ]);
 
                             $node               = clone$node;

--- a/src/Transforms/WrapQuery.php
+++ b/src/Transforms/WrapQuery.php
@@ -7,6 +7,7 @@ namespace GraphQLTools\Transforms;
 use GraphQL\Executor\ExecutionResult;
 use GraphQL\Language\AST\FieldNode;
 use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\SelectionSetNode;
 use GraphQL\Language\Visitor;
 
@@ -57,7 +58,7 @@ class WrapQuery implements Transform
                                 || (is_array($wrapResult) && $wrapResult['kind'] === NodeKind::SELECTION_SET)
                                 ? $wrapResult
                                 : new SelectionSetNode([
-                                    'selections' => [$wrapResult],
+                                    'selections' => NodeList::create([$wrapResult]),
                                 ]);
 
                             $node               = clone$node;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -19,6 +19,7 @@ use GraphQL\Utils\BlockString;
 use GraphQL\Utils\TypeComparators;
 use IteratorAggregate;
 use ReflectionProperty;
+
 use function array_filter;
 use function array_keys;
 use function array_reverse;
@@ -30,7 +31,7 @@ use function iterator_to_array;
 class Utils
 {
     /** @var string[] */
-    public static $specifiedScalarTypes = [
+    public static array $specifiedScalarTypes = [
         StringType::class,
         IntType::class,
         FloatType::class,
@@ -38,7 +39,7 @@ class Utils
         IDType::class,
     ];
 
-    public static function isSpecifiedScalarType(Type $type) : bool
+    public static function isSpecifiedScalarType(Type $type): bool
     {
         return $type instanceof NamedType &&
             (
@@ -50,7 +51,7 @@ class Utils
             );
     }
 
-    public static function implementsAbstractType(Schema $schema, Type $typeA, Type $typeB) : bool
+    public static function implementsAbstractType(Schema $schema, Type $typeA, Type $typeB): bool
     {
         if ($typeA === $typeB) {
             return true;
@@ -63,15 +64,17 @@ class Utils
         return false;
     }
 
-    private static function getLeadingCommentBlock(Node $node) : ?string
+    private static function getLeadingCommentBlock(Node $node): string|null
     {
         $loc = $node->loc;
         if (! $loc || ! $loc->startToken) {
             return null;
         }
+
         $comments = [];
         $token    = $loc->startToken->prev;
-        while ($token &&
+        while (
+            $token &&
             $token->kind === Token::COMMENT &&
             $token->next && $token->prev &&
             $token->line + 1 === $token->next->line &&
@@ -85,14 +88,13 @@ class Utils
         return implode("\n", array_reverse($comments));
     }
 
-    /**
-     * @param mixed[] $options
-     */
-    public static function getDescription(Node $node, array $options = []) : ?string
+    /** @param mixed[] $options */
+    public static function getDescription(Node $node, array $options = []): string|null
     {
         if (isset($node->description)) {
             return $node->description->value;
         }
+
         if (isset($options['commentDescriptions']) && $options['commentDescriptions']) {
             $rawValue = static::getLeadingCommentBlock($node);
             if ($rawValue !== null) {
@@ -103,41 +105,28 @@ class Utils
         return null;
     }
 
-    /**
-     * @param mixed $array
-     */
-    public static function isNumericArray($array) : bool
+    public static function isNumericArray(mixed $array): bool
     {
         return is_array($array) && (count(array_filter(array_keys($array), 'is_string')) === 0);
     }
 
-    /**
-     * @param mixed $value
-     */
-    public static function forceSet(object $subject, string $propertyName, $value) : void
+    public static function forceSet(object $subject, string $propertyName, mixed $value): void
     {
         $reflection = new ReflectionProperty($subject, $propertyName);
         $reflection->setAccessible(true);
         $reflection->setValue($subject, $value);
     }
 
-    /**
-     * @return mixed
-     */
-    public static function forceGet(object $subject, string $propertyName)
+    public static function forceGet(object $subject, string $propertyName): mixed
     {
         $reflection = new ReflectionProperty($subject, $propertyName);
         $reflection->setAccessible(true);
+
         return $reflection->getValue($subject);
     }
 
-
-    /**
-     * @param mixed $arrayLike
-     *
-     * @return mixed[]
-     */
-    public static function toArray($arrayLike) : array
+    /** @return mixed[] */
+    public static function toArray(mixed $arrayLike): array
     {
         if ($arrayLike instanceof IteratorAggregate) {
             return iterator_to_array($arrayLike->getIterator());

--- a/tests/AlternateMergeSchemasTest/InterfaceResolverInheritanceTest.php
+++ b/tests/AlternateMergeSchemasTest/InterfaceResolverInheritanceTest.php
@@ -11,14 +11,13 @@ use PHPUnit\Framework\TestCase;
 
 class InterfaceResolverInheritanceTest extends TestCase
 {
-    /** @var string */
-    private $testSchemaWithInterfaceResolvers;
+    private string $testSchemaWithInterfaceResolvers;
     /** @var mixed[] */
-    private $user;
+    private array $user;
     /** @var mixed[] */
-    private $resolvers;
+    private array $resolvers;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -46,12 +45,14 @@ class InterfaceResolverInheritanceTest extends TestCase
                 },
                 'id' => static function ($args) {
                     $id = $args['_id'];
+
                     return 'Node:' . $id;
                 },
             ],
             'User' => [
                 'name' => static function ($root) {
                     $name = $root['name'];
+
                     return 'User:' . $name;
                 },
             ],
@@ -63,10 +64,8 @@ class InterfaceResolverInheritanceTest extends TestCase
         ];
     }
 
-    /**
-     * @see it('copies resolvers from interface')
-     */
-    public function testCopiesResolversFromInterface() : void
+    /** @see it('copies resolvers from interface') */
+    public function testCopiesResolversFromInterface(): void
     {
         $mergedSchema = GraphQLTools::mergeSchemas([
             'schemas' => [
@@ -91,14 +90,12 @@ class InterfaceResolverInheritanceTest extends TestCase
                     ],
                 ],
             ],
-            $response->toArray()
+            $response->toArray(),
         );
     }
 
-    /**
-     * @see it('does not copy resolvers from interface when flag is false')
-     */
-    public function testDoesNotCopyResolversFromInterfaceWhenFlagIsFalse() : void
+    /** @see it('does not copy resolvers from interface when flag is false') */
+    public function testDoesNotCopyResolversFromInterfaceWhenFlagIsFalse(): void
     {
         $mergedSchema = GraphQLTools::mergeSchemas([
             'schemas' => [
@@ -118,10 +115,8 @@ class InterfaceResolverInheritanceTest extends TestCase
         static::assertEquals(['user', 'id'], $response->errors[0]->getPath());
     }
 
-    /**
-     * @see it('does not copy resolvers from interface when flag is not provided')
-     */
-    public function testDoesNotCopyResolversFromInterfaceWhenFlagIsNotProvided() : void
+    /** @see it('does not copy resolvers from interface when flag is not provided') */
+    public function testDoesNotCopyResolversFromInterfaceWhenFlagIsNotProvided(): void
     {
         $mergedSchema = GraphQLTools::mergeSchemas([
             'schemas' => [

--- a/tests/AlternateMergeSchemasTest/InterfaceResolverInheritanceTest.php
+++ b/tests/AlternateMergeSchemasTest/InterfaceResolverInheritanceTest.php
@@ -111,7 +111,7 @@ class InterfaceResolverInheritanceTest extends TestCase
         $query    = '{ user { id name } }';
         $response = GraphQL::executeQuery($mergedSchema, $query);
         static::assertCount(1, $response->errors);
-        static::assertEquals('Cannot return null for non-nullable field User.id.', $response->errors[0]->getMessage());
+        static::assertEquals('Cannot return null for non-nullable field "User.id".', $response->errors[0]->getMessage());
         static::assertEquals(['user', 'id'], $response->errors[0]->getPath());
     }
 
@@ -131,7 +131,7 @@ class InterfaceResolverInheritanceTest extends TestCase
         $query    = '{ user { id name } }';
         $response = GraphQL::executeQuery($mergedSchema, $query);
         static::assertCount(1, $response->errors);
-        static::assertEquals('Cannot return null for non-nullable field User.id.', $response->errors[0]->getMessage());
+        static::assertEquals('Cannot return null for non-nullable field "User.id".', $response->errors[0]->getMessage());
         static::assertEquals(['user', 'id'], $response->errors[0]->getPath());
     }
 }

--- a/tests/AlternateMergeSchemasTest/LinkSchema.php
+++ b/tests/AlternateMergeSchemasTest/LinkSchema.php
@@ -6,7 +6,7 @@ namespace GraphQLTools\Tests\AlternateMergeSchemasTest;
 
 class LinkSchema
 {
-    public static function get() : string
+    public static function get(): string
     {
         return '
             """

--- a/tests/AlternateMergeSchemasTest/MergeSchemasThroughTransformsTest.php
+++ b/tests/AlternateMergeSchemasTest/MergeSchemasThroughTransformsTest.php
@@ -16,16 +16,14 @@ use PHPUnit\Framework\TestCase;
 
 class MergeSchemasThroughTransformsTest extends TestCase
 {
-    /** @var Schema */
-    protected $transformedPropertySchema;
-    /** @var Schema */
-    protected $transformedBookingSchema;
-    /** @var Schema */
-    protected $mergedSchema;
+    protected Schema $transformedPropertySchema;
+    protected Schema $transformedBookingSchema;
+    protected Schema $mergedSchema;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
+
         $propertySchema = TestingSchemas::propertySchema();
         $bookingSchema  = TestingSchemas::bookingSchema();
 
@@ -35,19 +33,19 @@ class MergeSchemasThroughTransformsTest extends TestCase
                 new FilterRootFields(
                     static function ($operation, $rootField) {
                         return $operation . $rootField === 'Query.properties';
-                    }
+                    },
                 ),
                 new RenameTypes(
                     static function ($name) {
                         return 'Properties_' . $name;
-                    }
+                    },
                 ),
                 new RenameRootFields(
                     static function ($name) {
                         return 'Properties_' . $name;
-                    }
+                    },
                 ),
-            ]
+            ],
         );
 
         $this->transformedBookingSchema = GraphQLTools::transformSchema(
@@ -56,19 +54,19 @@ class MergeSchemasThroughTransformsTest extends TestCase
                 new FilterRootFields(
                     static function ($operation, $rootField) {
                         return $operation . $rootField === 'Query.bookings';
-                    }
+                    },
                 ),
                 new RenameTypes(
                     static function ($name) {
                         return 'Bookings_' . $name;
-                    }
+                    },
                 ),
                 new RenameRootFields(
                     static function ($name) {
                         return 'Booking_' . $name;
-                    }
+                    },
                 ),
-            ]
+            ],
         );
 
         $this->mergedSchema = GraphQLTools::mergeSchemas([
@@ -148,10 +146,8 @@ class MergeSchemasThroughTransformsTest extends TestCase
         ]);
     }
 
-    /**
-     * @see it('node should work')
-     */
-    public function testNodeShouldWork() : void
+    /** @see it('node should work') */
+    public function testNodeShouldWork(): void
     {
         $result = GraphQL::executeQuery(
             $this->mergedSchema,
@@ -185,7 +181,7 @@ class MergeSchemasThroughTransformsTest extends TestCase
             [
                 'pid' => 'p1',
                 'bid' => 'b1',
-            ]
+            ],
         );
 
         static::assertEquals(
@@ -220,7 +216,7 @@ class MergeSchemasThroughTransformsTest extends TestCase
                     ],
                 ],
             ],
-            $result->toArray()
+            $result->toArray(),
         );
     }
 }

--- a/tests/CircularSchemaA.php
+++ b/tests/CircularSchemaA.php
@@ -6,10 +6,8 @@ namespace GraphQLTools\Tests;
 
 class CircularSchemaA
 {
-    /**
-     * @return mixed[]
-     */
-    public static function build() : array
+    /** @return mixed[] */
+    public static function build(): array
     {
         return [
             '

--- a/tests/CircularSchemaB.php
+++ b/tests/CircularSchemaB.php
@@ -6,10 +6,8 @@ namespace GraphQLTools\Tests;
 
 class CircularSchemaB
 {
-    /**
-     * @return mixed[]
-     */
-    public static function build() : array
+    /** @return mixed[] */
+    public static function build(): array
     {
         return [
             '

--- a/tests/DelegateToSchemaTest.php
+++ b/tests/DelegateToSchemaTest.php
@@ -15,7 +15,7 @@ class DelegateToSchemaTest extends TestCase
      *
      * @return mixed[]
      */
-    protected static function findPropertyByLocationName(array $properties, string $name): array
+    protected static function findPropertyByLocationName(array $properties, string $name): array|null
     {
         foreach ($properties as $key => $property) {
             if ($property['location']['name'] === $name) {
@@ -104,6 +104,7 @@ class DelegateToSchemaTest extends TestCase
         );
 
         $coordinates = TestingSchemas::$sampleData['Property']['p1']['location']['coordinates'];
+
         static::assertEquals(
             [
                 'data' => [

--- a/tests/DelegateToSchemaTest.php
+++ b/tests/DelegateToSchemaTest.php
@@ -15,7 +15,7 @@ class DelegateToSchemaTest extends TestCase
      *
      * @return mixed[]
      */
-    protected static function findPropertyByLocationName(array $properties, string $name) : array
+    protected static function findPropertyByLocationName(array $properties, string $name): array
     {
         foreach ($properties as $key => $property) {
             if ($property['location']['name'] === $name) {
@@ -26,8 +26,7 @@ class DelegateToSchemaTest extends TestCase
         return null;
     }
 
-    /** @var string */
-    protected $COORDINATES_QUERY = '
+    protected string $COORDINATES_QUERY = '
         query BookingCoordinates($bookingId: ID!) {
             bookingById (id: $bookingId) {
                 property {
@@ -39,10 +38,8 @@ class DelegateToSchemaTest extends TestCase
         }
     ';
 
-    /**
-     * @return mixed[]
-     */
-    protected static function proxyResolvers(string $spec) : array
+    /** @return mixed[] */
+    protected static function proxyResolvers(string $spec): array
     {
         return [
             'Booking' => [
@@ -71,9 +68,10 @@ class DelegateToSchemaTest extends TestCase
                     'fragment' => '... on Location { name }',
                     'resolve' => static function ($location, $args, $context, $info) {
                         $name = $location['name'];
+
                         return static::findPropertyByLocationName(
                             TestingSchemas::$sampleData['Property'],
-                            $name
+                            $name,
                         )['location']['coordinates'];
                     },
                 ],
@@ -81,8 +79,7 @@ class DelegateToSchemaTest extends TestCase
         ];
     }
 
-    /** @var string */
-    protected $proxyTypeDefs = '
+    protected string $proxyTypeDefs = '
         extend type Booking {
             property: Property!
         }
@@ -91,7 +88,7 @@ class DelegateToSchemaTest extends TestCase
         }
     ';
 
-    public function testDelegateToSchemaStandaloneShouldAddFragmentsForDeepTypes() : void
+    public function testDelegateToSchemaStandaloneShouldAddFragmentsForDeepTypes(): void
     {
         $schema = GraphQLTools::mergeSchemas([
             'schemas' => [TestingSchemas::bookingSchema(), TestingSchemas::propertySchema(), $this->proxyTypeDefs],
@@ -103,7 +100,7 @@ class DelegateToSchemaTest extends TestCase
             $this->COORDINATES_QUERY,
             [],
             [],
-            ['bookingId' => 'b1']
+            ['bookingId' => 'b1'],
         );
 
         $coordinates = TestingSchemas::$sampleData['Property']['p1']['location']['coordinates'];
@@ -117,11 +114,11 @@ class DelegateToSchemaTest extends TestCase
                     ],
                 ],
             ],
-            $result->toArray()
+            $result->toArray(),
         );
     }
 
-    public function testDelegateToSchemaInfoMergeInfoShouldAddFragmentsForDeepTypes() : void
+    public function testDelegateToSchemaInfoMergeInfoShouldAddFragmentsForDeepTypes(): void
     {
         $schema = GraphQLTools::mergeSchemas([
             'schemas' => [TestingSchemas::bookingSchema(), TestingSchemas::propertySchema(), $this->proxyTypeDefs],
@@ -133,7 +130,7 @@ class DelegateToSchemaTest extends TestCase
             $this->COORDINATES_QUERY,
             [],
             [],
-            ['bookingId' => 'b1']
+            ['bookingId' => 'b1'],
         );
 
         $coordinates = TestingSchemas::$sampleData['Property']['p1']['location']['coordinates'];
@@ -147,7 +144,7 @@ class DelegateToSchemaTest extends TestCase
                     ],
                 ],
             ],
-            $result->toArray()
+            $result->toArray(),
         );
     }
 }

--- a/tests/DirectivesTest.php
+++ b/tests/DirectivesTest.php
@@ -34,11 +34,13 @@ use ReflectionClass;
 use ReflectionMethod;
 use stdClass;
 use Throwable;
+
 use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_search;
 use function array_slice;
+use function assert;
 use function call_user_func_array;
 use function count;
 use function get_class;
@@ -55,8 +57,7 @@ use function substr;
 
 class DirectivesTest extends TestCase
 {
-    /** @var string */
-    protected $typeDefs = '
+    protected string $typeDefs = '
         directive @schemaDirective(role: String) on SCHEMA
         directive @queryTypeDirective on OBJECT
         directive @queryFieldDirective on FIELD_DEFINITION
@@ -114,10 +115,8 @@ class DirectivesTest extends TestCase
         union WhateverUnion @unionDirective = Person | Query | Mutation
     ';
 
-    /**
-     * @see it('are included in the schema AST')
-     */
-    public function testAreIncludedInTheSchemaAST() : void
+    /** @see it('are included in the schema AST') */
+    public function testAreIncludedInTheSchemaAST(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->typeDefs,
@@ -133,24 +132,24 @@ class DirectivesTest extends TestCase
         $checkDirectives = static function (
             $type,
             $typeDirectiveNames,
-            $fieldDirectiveMap = []
-        ) use ($getDirectiveNames) : void {
+            $fieldDirectiveMap = [],
+        ) use ($getDirectiveNames): void {
             static::assertEquals(
                 $typeDirectiveNames,
-                $getDirectiveNames($type)
+                $getDirectiveNames($type),
             );
 
             foreach (array_keys($fieldDirectiveMap) as $key) {
                 static::assertEquals(
                     $fieldDirectiveMap[$key],
-                    $getDirectiveNames($type->getFields()[$key])
+                    $getDirectiveNames($type->getFields()[$key]),
                 );
             }
         };
 
         static::assertEquals(
             ['schemaDirective'],
-            $getDirectiveNames($schema)
+            $getDirectiveNames($schema),
         );
 
         $checkDirectives(
@@ -158,24 +157,24 @@ class DirectivesTest extends TestCase
             ['queryTypeDirective'],
             [
                 'people' => ['queryFieldDirective'],
-            ]
+            ],
         );
 
         static::assertEquals(
             ['enumTypeDirective'],
-            $getDirectiveNames($schema->getType('Gender'))
+            $getDirectiveNames($schema->getType('Gender')),
         );
 
         $nonBinary = $schema->getType('Gender')->getValues()[0];
 
         static::assertEquals(
             ['enumValueDirective'],
-            $getDirectiveNames($nonBinary)
+            $getDirectiveNames($nonBinary),
         );
 
         $checkDirectives(
             $schema->getType('Date'),
-            ['dateDirective']
+            ['dateDirective'],
         );
 
         $checkDirectives(
@@ -183,7 +182,7 @@ class DirectivesTest extends TestCase
             ['interfaceDirective'],
             [
                 'name' => ['interfaceFieldDirective'],
-            ]
+            ],
         );
 
         $checkDirectives(
@@ -192,7 +191,7 @@ class DirectivesTest extends TestCase
             [
                 'name' => ['inputFieldDirective'],
                 'gender' => [],
-            ]
+            ],
         );
 
         $checkDirectives(
@@ -200,12 +199,12 @@ class DirectivesTest extends TestCase
             ['mutationTypeDirective'],
             [
                 'addPerson' => ['mutationMethodDirective'],
-            ]
+            ],
         );
 
         static::assertEquals(
             ['mutationArgumentDirective'],
-            $getDirectiveNames($schema->getMutationType()->getFields()['addPerson']->args[0])
+            $getDirectiveNames($schema->getMutationType()->getFields()['addPerson']->args[0]),
         );
 
         $checkDirectives(
@@ -214,19 +213,17 @@ class DirectivesTest extends TestCase
             [
                 'id' => ['objectFieldDirective'],
                 'name' => [],
-            ]
+            ],
         );
 
         $checkDirectives(
             $schema->getType('WhateverUnion'),
-            ['unionDirective']
+            ['unionDirective'],
         );
     }
 
-    /**
-     * @see it('can be implemented with SchemaDirectiveVisitor')
-     */
-    public function testCanBeImplementedWithSchemaDirectiveVisitor() : void
+    /** @see it('can be implemented with SchemaDirectiveVisitor') */
+    public function testCanBeImplementedWithSchemaDirectiveVisitor(): void
     {
         $visited    = [];
         $schema     = GraphQLTools::makeExecutableSchema([
@@ -240,30 +237,26 @@ class DirectivesTest extends TestCase
             [
                 'queryTypeDirective' => new class ($visited, $visitCount) extends SchemaDirectiveVisitor
                 {
-                    /** @var string */
-                    public static $description = 'A @directive for query object types';
+                    public static string $description = 'A @directive for query object types';
                     /** @var ObjectType[] */
-                    protected $visited;
-                    /** @var int */
-                    protected $visitCount;
+                    protected array $visited;
+                    protected int $visitCount;
 
-                    /**
-                     * @param ObjectType[] $visited
-                     */
+                    /** @param ObjectType[] $visited */
                     public function __construct(array &$visited, int &$visitCount)
                     {
                         $this->visited    = &$visited;
                         $this->visitCount = &$visitCount;
                     }
 
-                    public function visitObject(ObjectType $object) : void
+                    public function visitObject(ObjectType $object): void
                     {
                         $this->visited[] = $object;
 
                         $this->visitCount++;
                     }
                 },
-            ]
+            ],
         );
 
         static::assertEquals(1, count($visited));
@@ -273,10 +266,8 @@ class DirectivesTest extends TestCase
         }
     }
 
-    /**
-     * @see it('can visit the schema itself')
-     */
-    public function testCanVisitTheSchemaItself() : void
+    /** @see it('can visit the schema itself') */
+    public function testCanVisitTheSchemaItself(): void
     {
         $visited = [];
         $schema  = GraphQLTools::makeExecutableSchema([
@@ -290,32 +281,28 @@ class DirectivesTest extends TestCase
                 'schemaDirective' => new class ($visited) extends SchemaDirectiveVisitor
                 {
                     /** @var Schema[] */
-                    private $visited;
+                    private array $visited;
 
-                    /**
-                     * @param Schema[] $visited
-                     */
+                    /** @param Schema[] $visited */
                     public function __construct(array &$visited)
                     {
                         $this->visited = &$visited;
                     }
 
-                    public function visitSchema(Schema $s) : void
+                    public function visitSchema(Schema $s): void
                     {
                         $this->visited[] = $s;
                     }
                 },
-            ]
+            ],
         );
 
         static::assertCount(1, $visited);
         static::assertEquals($schema, $visited[0]);
     }
 
-    /**
-     * @see it('can visit fields within object types')
-     */
-    public function testCanVisitFieldsWithinObjectTypes() : void
+    /** @see it('can visit fields within object types') */
+    public function testCanVisitFieldsWithinObjectTypes(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->typeDefs,
@@ -332,15 +319,14 @@ class DirectivesTest extends TestCase
             [
                 'mutationTypeDirective' => new class ($mutationObjectType) extends SchemaDirectiveVisitor
                 {
-                    /** @var ObjectType */
-                    private $mutationObjectType;
+                    private ObjectType $mutationObjectType;
 
-                    public function __construct(?ObjectType &$mutationObjectType)
+                    public function __construct(ObjectType|null &$mutationObjectType)
                     {
                         $this->mutationObjectType = &$mutationObjectType;
                     }
 
-                    public function visitObject(ObjectType $object) : void
+                    public function visitObject(ObjectType $object): void
                     {
                         $this->mutationObjectType = $object;
                         TestCase::assertEquals($object, $this->visitedType);
@@ -348,23 +334,21 @@ class DirectivesTest extends TestCase
                     }
                 },
                 'mutationMethodDirective' => new class (
-                    $mutationObjectType, $mutationField) extends SchemaDirectiveVisitor
+                    $mutationObjectType,
+                    $mutationField
+                ) extends SchemaDirectiveVisitor
                 {
-                    /** @var ObjectType */
-                    private $mutationObjectType;
-                    /** @var FieldDefinition */
-                    private $mutationField;
+                    private ObjectType $mutationObjectType;
+                    private FieldDefinition $mutationField;
 
-                    public function __construct(?ObjectType &$mutationObjectType, ?FieldDefinition &$mutationField)
+                    public function __construct(ObjectType|null &$mutationObjectType, FieldDefinition|null &$mutationField)
                     {
                         $this->mutationObjectType = &$mutationObjectType;
                         $this->mutationField      = &$mutationField;
                     }
 
-                    /**
-                     * @param mixed[] $details
-                     */
-                    public function visitFieldDefinition(FieldDefinition $field, array $details) : void
+                    /** @param mixed[] $details */
+                    public function visitFieldDefinition(FieldDefinition $field, array $details): void
                     {
                         TestCase::assertEquals($field, $this->visitedType);
                         TestCase::assertEquals('addPerson', $field->name);
@@ -379,21 +363,17 @@ class DirectivesTest extends TestCase
                     $mutationField
                 ) extends SchemaDirectiveVisitor
                 {
-                    /** @var ObjectType */
-                    private $mutationObjectType;
-                    /** @var FieldDefinition */
-                    private $mutationField;
+                    private ObjectType $mutationObjectType;
+                    private FieldDefinition $mutationField;
 
-                    public function __construct(?ObjectType &$mutationObjectType, ?FieldDefinition &$mutationField)
+                    public function __construct(ObjectType|null &$mutationObjectType, FieldDefinition|null &$mutationField)
                     {
                         $this->mutationObjectType = &$mutationObjectType;
                         $this->mutationField      = &$mutationField;
                     }
 
-                    /**
-                     * @param mixed[] $details
-                     */
-                    public function visitArgumentDefinition(FieldArgument $arg, array $details) : void
+                    /** @param mixed[] $details */
+                    public function visitArgumentDefinition(FieldArgument $arg, array $details): void
                     {
                         TestCase::assertEquals($arg, $this->visitedType);
                         TestCase::assertEquals('input', $arg->name);
@@ -404,15 +384,14 @@ class DirectivesTest extends TestCase
                 },
                 'enumTypeDirective' => new class ($enumObjectType) extends SchemaDirectiveVisitor
                 {
-                    /** @var EnumType */
-                    private $enumObjectType;
+                    private EnumType $enumObjectType;
 
-                    public function __construct(?EnumType &$enumObjectType)
+                    public function __construct(EnumType|null &$enumObjectType)
                     {
                         $this->enumObjectType = &$enumObjectType;
                     }
 
-                    public function visitEnum(EnumType $enumType) : void
+                    public function visitEnum(EnumType $enumType): void
                     {
                         TestCase::assertEquals($enumType, $this->visitedType);
                         TestCase::assertEquals('Gender', $enumType->name);
@@ -421,20 +400,15 @@ class DirectivesTest extends TestCase
                 },
                 'enumValueDirective' => new class ($enumObjectType) extends SchemaDirectiveVisitor
                 {
-                    /** @var EnumType */
-                    private $enumObjectType;
+                    private EnumType $enumObjectType;
 
-                    public function __construct(?EnumType &$enumObjectType)
+                    public function __construct(EnumType|null &$enumObjectType)
                     {
                         $this->enumObjectType = &$enumObjectType;
                     }
 
-                    /**
-                     * @param mixed[] $details
-                     *
-                     * @return mixed|void
-                     */
-                    public function visitEnumValue(EnumValueDefinition $value, array $details)
+                    /** @param mixed[] $details */
+                    public function visitEnumValue(EnumValueDefinition $value, array $details): mixed
                     {
                         TestCase::assertEquals($value, $this->visitedType);
                         TestCase::assertEquals('NONBINARY', $value->name);
@@ -444,15 +418,14 @@ class DirectivesTest extends TestCase
                 },
                 'inputTypeDirective' => new class ($inputObjectType) extends SchemaDirectiveVisitor
                 {
-                    /** @var InputObjectType */
-                    private $inputObjectType;
+                    private InputObjectType $inputObjectType;
 
-                    public function __construct(?InputObjectType &$inputObjectType)
+                    public function __construct(InputObjectType|null &$inputObjectType)
                     {
                         $this->inputObjectType = &$inputObjectType;
                     }
 
-                    public function visitInputObject(InputObjectType $object) : void
+                    public function visitInputObject(InputObjectType $object): void
                     {
                         $this->inputObjectType = $object;
                         TestCase::assertEquals($object, $this->visitedType);
@@ -461,40 +434,35 @@ class DirectivesTest extends TestCase
                 },
                 'inputFieldDirective' => new class ($inputObjectType) extends SchemaDirectiveVisitor
                 {
-                    /** @var InputObjectType */
-                    private $inputObjectType;
+                    private InputObjectType $inputObjectType;
 
-                    public function __construct(?InputObjectType &$inputObjectType)
+                    public function __construct(InputObjectType|null &$inputObjectType)
                     {
                         $this->inputObjectType = &$inputObjectType;
                     }
 
-                    /**
-                     * @param mixed[] $details
-                     */
-                    public function visitInputFieldDefinition(InputObjectField $field, array $details) : void
+                    /** @param mixed[] $details */
+                    public function visitInputFieldDefinition(InputObjectField $field, array $details): void
                     {
                         TestCase::assertEquals($field, $this->visitedType);
                         TestCase::assertEquals('name', $field->name);
                         TestCase::assertEquals($this->inputObjectType, $details['objectType']);
                     }
                 },
-            ]
+            ],
         );
     }
 
-    /**
-     * @see it('can check if a visitor method is implemented')
-     */
-    public function testCanCheckIfAVisitorMethodIsImplemented() : void
+    /** @see it('can check if a visitor method is implemented') */
+    public function testCanCheckIfAVisitorMethodIsImplemented(): void
     {
         $visitor = new class extends SchemaVisitor
         {
-            public function notVisitorMethod() : void
+            public function notVisitorMethod(): void
             {
             }
 
-            public function visitObject(ObjectType $object) : ObjectType
+            public function visitObject(ObjectType $object): ObjectType
             {
                 return $object;
             }
@@ -509,7 +477,7 @@ class DirectivesTest extends TestCase
     /**
      * it('can use visitSchema for simple visitor patterns')
      */
-    public function testCanUseVisitSchemaForSimpleVisitorPatterns() : void
+    public function testCanUseVisitSchemaForSimpleVisitorPatterns(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->typeDefs,
@@ -518,17 +486,16 @@ class DirectivesTest extends TestCase
 
         $simpleVisitor = new class ($schema) extends SchemaVisitor
         {
-            /** @var int */
-            public $visitCount = 0;
+            public int $visitCount = 0;
             /** @var string[] */
-            public $names = [];
+            public array $names = [];
 
             public function __construct(Schema $s)
             {
                 $this->schema = $s;
             }
 
-            public function visit() : void
+            public function visit(): void
             {
                 // More complicated visitor implementations might use the
                 // visitorSelector function more selectively, but this SimpleVisitor
@@ -537,11 +504,11 @@ class DirectivesTest extends TestCase
                     $this->schema,
                     function () {
                         return [$this];
-                    }
+                    },
                 );
             }
 
-            public function visitObject(ObjectType $object) : void
+            public function visitObject(ObjectType $object): void
             {
                 TestCase::assertEquals($object, $this->schema->getType($object->name));
                 $this->names[] = $object->name;
@@ -557,14 +524,12 @@ class DirectivesTest extends TestCase
                 'Person',
                 'Query',
             ],
-            $simpleVisitor->names
+            $simpleVisitor->names,
         );
     }
 
-    /**
-     * @see it('can use SchemaDirectiveVisitor as a no-op visitor')
-     */
-    public function testCanUseSchemaDirectiveVisitorAsANoOpVisitor() : void
+    /** @see it('can use SchemaDirectiveVisitor as a no-op visitor') */
+    public function testCanUseSchemaDirectiveVisitorAsANoOpVisitor(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->typeDefs,
@@ -576,9 +541,9 @@ class DirectivesTest extends TestCase
         $enthusiasticVisitor = new class extends SchemaDirectiveVisitor
         {
             /** @var bool[] */
-            public static $methodNamesEncountered;
+            public static array $methodNamesEncountered;
 
-            public static function implementsVisitorMethod(string $name) : bool
+            public static function implementsVisitorMethod(string $name): bool
             {
                 // Pretend this class implements all visitor methods. This is safe
                 // because the SchemaVisitor base class provides empty stubs for all
@@ -608,7 +573,7 @@ class DirectivesTest extends TestCase
                 'objectTypeDirective' => $enthusiasticVisitor,
                 'objectFieldDirective' => $enthusiasticVisitor,
                 'unionDirective' => $enthusiasticVisitor,
-            ]
+            ],
         );
 
         $reflection = new ReflectionClass($enthusiasticVisitor);
@@ -632,14 +597,12 @@ class DirectivesTest extends TestCase
 
         static::assertEquals(
             $methodNames,
-            $methodNamesEncountered
+            $methodNamesEncountered,
         );
     }
 
-    /**
-     * @see it('can handle declared arguments')
-     */
-    public function testCanHandleDeclaredArguments() : void
+    /** @see it('can handle declared arguments') */
+    public function testCanHandleDeclaredArguments(): void
     {
         $schemaText = '
             directive @oyez(
@@ -671,10 +634,9 @@ class DirectivesTest extends TestCase
 
         $oyezVisitor = new class extends SchemaDirectiveVisitor
         {
-            /** @var Schema */
-            public static $mySchema;
+            public static Schema $mySchema;
 
-            public static function getDirectiveDeclaration(string $name, Schema $theSchema) : ?Directive
+            public static function getDirectiveDeclaration(string $name, Schema $theSchema): Directive|null
             {
                 $schema = static::$mySchema;
                 TestCase::assertEquals($schema, $theSchema);
@@ -691,16 +653,14 @@ class DirectivesTest extends TestCase
                 return $prev;
             }
 
-            public function visitObject(ObjectType $object) : void
+            public function visitObject(ObjectType $object): void
             {
                 ++$this->context->objectCount;
                 TestCase::assertEquals(3, $this->args['times']);
             }
 
-            /**
-             * @param mixed[] $details
-             */
-            public function visitFieldDefinition(FieldDefinition $field, array $details) : void
+            /** @param mixed[] $details */
+            public function visitFieldDefinition(FieldDefinition $field, array $details): void
             {
                 ++$this->context->fieldCount;
                 if ($field->name === 'judge') {
@@ -710,6 +670,7 @@ class DirectivesTest extends TestCase
                         TestCase::assertEquals(3, $this->args['times']);
                     }
                 }
+
                 TestCase::assertEquals('IMPARTIAL', $this->args['party']);
             }
         };
@@ -719,7 +680,7 @@ class DirectivesTest extends TestCase
         $visitors = SchemaDirectiveVisitor::visitSchemaDirectives(
             $schema,
             ['oyez' => $oyezVisitor],
-            $context
+            $context,
         );
 
         static::assertEquals(1, $context->objectCount);
@@ -730,14 +691,12 @@ class DirectivesTest extends TestCase
             ['Courtroom', 'judge', 'marshall'],
             array_map(static function ($v) {
                 return $v->visitedType->name;
-            }, $visitors['oyez'])
+            }, $visitors['oyez']),
         );
     }
 
-    /**
-     * @see it('can be used to implement the @upper example')
-     */
-    public function testCanBeUsedToImplementTheUpperExample() : void
+    /** @see it('can be used to implement the @upper example') */
+    public function testCanBeUsedToImplementTheUpperExample(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => '
@@ -749,10 +708,8 @@ class DirectivesTest extends TestCase
             'schemaDirectives' => [
                 'upper' => new class extends SchemaDirectiveVisitor
                 {
-                    /**
-                     * @param mixed[] $detail
-                     */
-                    public function visitFieldDefinition(FieldDefinition $field, array $detail) : void
+                    /** @param mixed[] $detail */
+                    public function visitFieldDefinition(FieldDefinition $field, array $detail): void
                     {
                         $resolve          = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
                         $field->resolveFn = static function (...$args) use ($resolve) {
@@ -760,6 +717,7 @@ class DirectivesTest extends TestCase
                             if (is_string($result)) {
                                 return strtoupper($result);
                             }
+
                             return $result;
                         };
                     }
@@ -780,16 +738,14 @@ class DirectivesTest extends TestCase
                 query {
                     hello
                 }
-            '
+            ',
         );
 
         static::assertEquals(['hello' => 'HELLO WORLD'], $result->data);
     }
 
-    /**
-     * @see it('can be used to implement the @date example')
-     */
-    public function testCanBeUsedToImplementTheDateExample() : void
+    /** @see it('can be used to implement the @date example') */
+    public function testCanBeUsedToImplementTheDateExample(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => '
@@ -802,10 +758,8 @@ class DirectivesTest extends TestCase
             'schemaDirectives' => [
                 'date' => new class extends SchemaDirectiveVisitor
                 {
-                    /**
-                     * @param mixed[] $detail
-                     */
-                    public function visitFieldDefinition(FieldDefinition $field, array $detail) : void
+                    /** @param mixed[] $detail */
+                    public function visitFieldDefinition(FieldDefinition $field, array $detail): void
                     {
                         $resolve = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
                         $format  = $this->args['format'];
@@ -814,6 +768,7 @@ class DirectivesTest extends TestCase
 
                         $field->resolveFn = static function (...$args) use ($resolve, $format) {
                             $date = $resolve(...$args);
+
                             return DateTime::createFromFormat(DateTime::ATOM, $date)->format($format);
                         };
                     }
@@ -830,26 +785,22 @@ class DirectivesTest extends TestCase
 
         $result = GraphQL::executeQuery(
             $schema,
-            'query { today }'
+            'query { today }',
         );
 
         static::assertEquals(
             ['today' => 'February 26, 2018'],
-            $result->data
+            $result->data,
         );
     }
 
-    /**
-     * @see it('can be used to implement the @date by adding an argument')
-     */
-    public function testCanBeUsedToImplementTheDateByAddingAnArgument() : void
+    /** @see it('can be used to implement the @date by adding an argument') */
+    public function testCanBeUsedToImplementTheDateByAddingAnArgument(): void
     {
         $formattableDateDirective = new class extends SchemaDirectiveVisitor
         {
-            /**
-             * @param mixed[] $detail
-             */
-            public function visitFieldDefinition(FieldDefinition $field, array $detail) : void
+            /** @param mixed[] $detail */
+            public function visitFieldDefinition(FieldDefinition $field, array $detail): void
             {
                 $resolve       = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
                 $defaultFormat = $this->args['defaultFormat'];
@@ -863,6 +814,7 @@ class DirectivesTest extends TestCase
                 $field->resolveFn = static function ($source, $args, $context, $info) use ($resolve, $defaultFormat) {
                     $format = $args['format'] ?? $defaultFormat;
                     $date   = $resolve($source, $args, $context, $info);
+
                     return $date->format($format);
                 };
             }
@@ -884,6 +836,7 @@ class DirectivesTest extends TestCase
                     'today' => static function () {
                         $date = new DateTime();
                         $date->setTimestamp(1521131357);
+
                         return $date;
                     },
                 ],
@@ -898,7 +851,7 @@ class DirectivesTest extends TestCase
 
         static::assertEquals(
             ['today' => 'March 15, 2018'],
-            $resultNoArg->data
+            $resultNoArg->data,
         );
 
         $resultWithArg = GraphQL::executeQuery($schema, 'query { today(format: "d M Y") }');
@@ -909,19 +862,18 @@ class DirectivesTest extends TestCase
 
         static::assertEquals(
             ['today' => '15 Mar 2018'],
-            $resultWithArg->data
+            $resultWithArg->data,
         );
     }
 
-    /**
-     * @see it('can be used to implement the @intl example')
-     */
-    public function testCanBeUsedToImplementTheIntlExample() : void
+    /** @see it('can be used to implement the @intl example') */
+    public function testCanBeUsedToImplementTheIntlExample(): void
     {
         $translate = static function ($text, $path, $locale) {
             static::assertEquals('hello', $text);
             static::assertEquals(['Query', 'greeting'], $path);
             static::assertEquals('fr', $locale);
+
             return 'bonjour';
         };
 
@@ -937,24 +889,17 @@ class DirectivesTest extends TestCase
             'schemaDirectives' => [
                 'intl' => new class ($context, $translate) extends SchemaDirectiveVisitor
                 {
-                    /** @var mixed[] */
-                    private $ctx;
                     /** @var callable */
                     private $translate;
 
-                    /**
-                     * @param mixed[] $ctx
-                     */
-                    public function __construct(array $ctx, callable $translate)
+                    /** @param mixed[] $ctx */
+                    public function __construct(private array $ctx, callable $translate)
                     {
-                        $this->ctx       = $ctx;
                         $this->translate = $translate;
                     }
 
-                    /**
-                     * @param mixed[] $details
-                     */
-                    public function visitFieldDefinition(FieldDefinition $field, array $details) : void
+                    /** @param mixed[] $details */
+                    public function visitFieldDefinition(FieldDefinition $field, array $details): void
                     {
                         $resolve          = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
                         $field->resolveFn = function (...$args) use ($resolve, $details, $field) {
@@ -963,6 +908,7 @@ class DirectivesTest extends TestCase
                             $path = [$details['objectType']->name, $field->name];
                             TestCase::assertEquals($this->ctx, $args[2]);
                             $translate = $this->translate;
+
                             return $translate($defaultText, $path, $this->ctx['locale']);
                         };
                     }
@@ -981,19 +927,17 @@ class DirectivesTest extends TestCase
             $schema,
             'query {greeting }',
             null,
-            $context
+            $context,
         );
 
         static::assertEquals(
             ['greeting' => 'bonjour'],
-            $result->data
+            $result->data,
         );
     }
 
-    /**
-     * @see it('can be used to implement the @auth example')
-     */
-    public function testCanBeUsedToImplementTHeAuthExample() : void
+    /** @see it('can be used to implement the @auth example') */
+    public function testCanBeUsedToImplementTHeAuthExample(): void
     {
         $roles = [
             'UNKNOWN',
@@ -1005,21 +949,12 @@ class DirectivesTest extends TestCase
         $getUser = function ($token) use ($roles) {
             return new class ($token, $roles)
             {
-                /** @var string */
-                private $token;
-                /** @var string[] */
-                private $roles;
-
-                /**
-                 * @param string[] $roles
-                 */
-                public function __construct(string $token, array $roles)
+                /** @param string[] $roles */
+                public function __construct(private string $token, private array $roles)
                 {
-                    $this->token = $token;
-                    $this->roles = $roles;
                 }
 
-                public function hasRole(string $role) : bool
+                public function hasRole(string $role): bool
                 {
                     $tokenIndex = array_search($this->token, $this->roles);
                     $roleIndex  = array_search($role, $this->roles);
@@ -1039,29 +974,30 @@ class DirectivesTest extends TestCase
                 $this->getUser = $getUser;
             }
 
-            public function visitObject(ObjectType $type) : void
+            public function visitObject(ObjectType $type): void
             {
                 $this->ensureFieldsWrapped($type);
                 $type->_requiredAuthRole = $this->args['requires'];
             }
+
             // Visitor methods for nested types like fields and arguments
             // also receive a details object that provides information about
             // the parent and grandparent types.
-            /**
-             * @param mixed[] $details
-             */
-            public function visitFieldDefinition(FieldDefinition $field, array $details) : void
+
+            /** @param mixed[] $details */
+            public function visitFieldDefinition(FieldDefinition $field, array $details): void
             {
                 $this->ensureFieldsWrapped($details['objectType']);
                 $field->_requiredAuthRole = $this->args['requires'];
             }
 
-            public function ensureFieldsWrapped(ObjectType $objectType) : void
+            public function ensureFieldsWrapped(ObjectType $objectType): void
             {
                 // Mark the GraphQLObjectType object to avoid re-wrapping:
                 if ($objectType->_authFieldsWrapped ?? false) {
                     return;
                 }
+
                 $objectType->_authFieldsWrapped = true;
 
                 $fields = $objectType->getFields();
@@ -1145,7 +1081,7 @@ class DirectivesTest extends TestCase
                 null,
                 [
                     'headers' => ['authToken' => $role],
-                ]
+                ],
             );
         };
 
@@ -1167,7 +1103,7 @@ class DirectivesTest extends TestCase
             sort($actualNames);
             static::assertEquals(
                 $expectedNames,
-                $actualNames
+                $actualNames,
             );
 
             return $data;
@@ -1191,7 +1127,7 @@ class DirectivesTest extends TestCase
      *
      * @see it('can be used to implement the @length example')
      */
-    public function testCanBeUsedToImplementTheLengthExample() : void
+    public function testCanBeUsedToImplementTheLengthExample(): void
     {
         $createLimitedLengthType = function ($type, $maxLength) {
             return new class ($type, $maxLength) extends CustomScalarType
@@ -1206,7 +1142,7 @@ class DirectivesTest extends TestCase
 
                             if (strlen($value) > $maxLength) {
                                 return reject(
-                                    new Error(sprintf('expected %s to be at most %s', strlen($value), $maxLength))
+                                    new Error(sprintf('expected %s to be at most %s', strlen($value), $maxLength)),
                                 );
                             }
 
@@ -1250,36 +1186,31 @@ class DirectivesTest extends TestCase
                         $this->createLimitedLengthType = $createLimitedLengthType;
                     }
 
-                    /**
-                     * @param mixed[] $details
-                     */
-                    public function visitInputFieldDefinition(InputObjectField $field, array $details) : void
+                    /** @param mixed[] $details */
+                    public function visitInputFieldDefinition(InputObjectField $field, array $details): void
                     {
                         $this->wrapType($field);
                     }
 
-                    /**
-                     * @param mixed[] $details
-                     */
-                    public function visitFieldDefinition(FieldDefinition $field, array $details) : void
+                    /** @param mixed[] $details */
+                    public function visitFieldDefinition(FieldDefinition $field, array $details): void
                     {
                         $this->wrapType($field);
                     }
 
-                    /**
-                     * @param FieldDefinition|InputObjectField $field
-                     */
-                    private function wrapType($field) : void
+                    private function wrapType(FieldDefinition|InputObjectField $field): void
                     {
                         $createLimitedLengthType = $this->createLimitedLengthType;
-                        if ($field->getType() instanceof NonNull
-                            && $field->getType()->getWrappedType() instanceof ScalarType) {
+                        if (
+                            $field->getType() instanceof NonNull
+                            && $field->getType()->getWrappedType() instanceof ScalarType
+                        ) {
                             Utils::forceSet(
                                 $field,
                                 'type',
                                 new NonNull(
-                                    $createLimitedLengthType($field->getType()->getWrappedType(), $this->args['max'])
-                                )
+                                    $createLimitedLengthType($field->getType()->getWrappedType(), $this->args['max']),
+                                ),
                             );
                         } else {
                             if (! ($field->getType() instanceof ScalarType)) {
@@ -1289,7 +1220,7 @@ class DirectivesTest extends TestCase
                             Utils::forceSet(
                                 $field,
                                 'type',
-                                $createLimitedLengthType($field->getType(), $this->args['max'])
+                                $createLimitedLengthType($field->getType(), $this->args['max']),
                             );
                         }
                     }
@@ -1320,7 +1251,7 @@ class DirectivesTest extends TestCase
                         title
                     }
                 }
-            '
+            ',
         )->then(static function ($result) use ($schema) {
             $errors = $result->errors;
 
@@ -1336,23 +1267,21 @@ class DirectivesTest extends TestCase
                             title
                         }
                     }
-                '
+                ',
             );
-        })->then(static function ($result) : void {
+        })->then(static function ($result): void {
             static::assertEmpty($result->errors);
             static::assertEquals(
                 [
                     'createBook' => ['title' => 'safe title'],
                 ],
-                $result->data
+                $result->data,
             );
         });
     }
 
-    /**
-     * @see it('can be used to implement the @uniqueID example')
-     */
-    public function testCanBeUsedToImplementTheUniqueIDExample() : void
+    /** @see it('can be used to implement the @uniqueID example') */
+    public function testCanBeUsedToImplementTheUniqueIDExample(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => '
@@ -1373,7 +1302,7 @@ class DirectivesTest extends TestCase
             'schemaDirectives' => [
                 'uniqueID' => new class extends SchemaDirectiveVisitor
                 {
-                    public function visitObject(ObjectType $type) : void
+                    public function visitObject(ObjectType $type): void
                     {
                         ['name' => $name, 'from' => $from] = $this->args;
                         $fields                            = $type->getFields();
@@ -1387,6 +1316,7 @@ class DirectivesTest extends TestCase
                                 foreach ($from as $fieldName) {
                                     $hash .= $object[$fieldName];
                                 }
+
                                 return sha1($hash);
                             },
                         ]);
@@ -1431,7 +1361,7 @@ class DirectivesTest extends TestCase
                         address
                     }
                 }
-            '
+            ',
         );
 
         $data = $result->data;
@@ -1444,7 +1374,7 @@ class DirectivesTest extends TestCase
                     'name' => 'Ben',
                 ],
             ],
-            $data['people']
+            $data['people'],
         );
 
         static::assertEquals(
@@ -1455,14 +1385,12 @@ class DirectivesTest extends TestCase
                     'address' => '140 10th St',
                 ],
             ],
-            $data['locations']
+            $data['locations'],
         );
     }
 
-    /**
-     * @see it('automatically updates references to changed types')
-     */
-    public function testAutomaticallyUpdatesReferencesToChangedTypes() : void
+    /** @see it('automatically updates references to changed types') */
+    public function testAutomaticallyUpdatesReferencesToChangedTypes(): void
     {
         $HumanType = null;
         $schema    = GraphQLTools::makeExecutableSchema([
@@ -1470,18 +1398,18 @@ class DirectivesTest extends TestCase
             'schemaDirectives' => [
                 'objectTypeDirective' => new class ($HumanType) extends SchemaDirectiveVisitor
                 {
-                    /** @var ObjectType */
-                    private $HumanType;
+                    private ObjectType $HumanType;
 
-                    public function __construct(?ObjectType &$HumanType)
+                    public function __construct(ObjectType|null &$HumanType)
                     {
                         $this->HumanType = &$HumanType;
                     }
 
-                    public function visitObject(ObjectType $object) : ObjectType
+                    public function visitObject(ObjectType $object): ObjectType
                     {
                         $this->HumanType       = clone $object;
                         $this->HumanType->name = 'Human';
+
                         return $this->HumanType;
                     }
                 },
@@ -1519,14 +1447,12 @@ class DirectivesTest extends TestCase
         try {
             $schema->getType('Person');
             static::fail();
-        } catch (Throwable $e) {
+        } catch (Throwable) {
         }
     }
 
-    /**
-     * @see it('can remove enum values')
-     */
-    public function testCanRemoveEnumValues() : void
+    /** @see it('can remove enum values') */
+    public function testCanRemoveEnumValues(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => '
@@ -1543,10 +1469,8 @@ class DirectivesTest extends TestCase
             'schemaDirectives' => [
                 'remove' => new class extends SchemaDirectiveVisitor
                 {
-                    /**
-                     * @param mixed[] $details
-                     */
-                    public function visitEnumValue(EnumValueDefinition $value, array $details) : ?VisitorOperation
+                    /** @param mixed[] $details */
+                    public function visitEnumValue(EnumValueDefinition $value, array $details): VisitorOperation|null
                     {
                         if ($this->args['if']) {
                             return SchemaDirectiveVisitor::removeNode();
@@ -1566,15 +1490,13 @@ class DirectivesTest extends TestCase
                 static function ($value) {
                     return $value->name;
                 },
-                $AgeUnit->getValues()
-            )
+                $AgeUnit->getValues(),
+            ),
         );
     }
 
-    /**
-     * @see it('can swap names of GraphQLNamedType objects')
-     */
-    public function testCanSwapNamesOfGraphQLNamedTypeObjects() : void
+    /** @see it('can swap names of GraphQLNamedType objects') */
+    public function testCanSwapNamesOfGraphQLNamedTypeObjects(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => '
@@ -1593,7 +1515,7 @@ class DirectivesTest extends TestCase
             'schemaDirectives' => [
                 'rename' => new class extends SchemaDirectiveVisitor
                 {
-                    public function visitObject(ObjectType $object) : void
+                    public function visitObject(ObjectType $object): void
                     {
                         $object->name = $this->args['to'];
                     }
@@ -1601,26 +1523,24 @@ class DirectivesTest extends TestCase
             ],
         ]);
 
-        /** @var ObjectType $Human */
         $Human = $schema->getType('Human');
+        assert($Human instanceof ObjectType);
         static::assertEquals('Human', $Human->name);
         static::assertEquals(Type::int(), $Human->getField('heightInInches')->getType());
 
-        /** @var ObjectType $Person */
         $Person = $schema->getType('Person');
+        assert($Person instanceof ObjectType);
         static::assertEquals('Person', $Person->name);
         static::assertEquals($schema->getType('Date'), $Person->getField('born')->getType());
 
-        $Query = $schema->getQueryType();
-        /** @var ListOfType $peopleType */
+        $Query      = $schema->getQueryType();
         $peopleType = $Query->getField('people')->getType();
+        assert($peopleType instanceof ListOfType);
         static::assertEquals($Human, $peopleType->ofType);
     }
 
-    /**
-     * @see it('does not enforce query directive locations (issue #680)')
-     */
-    public function testDoesNotEnforceQueryDirectiveLocations() : void
+    /** @see it('does not enforce query directive locations (issue #680)') */
+    public function testDoesNotEnforceQueryDirectiveLocations(): void
     {
         $visited = [];
         $schema  = GraphQLTools::makeExecutableSchema([
@@ -1634,17 +1554,15 @@ class DirectivesTest extends TestCase
                 'hasScope' => new class ($visited) extends SchemaDirectiveVisitor
                 {
                     /** @var ObjectType[] */
-                    private $visited;
+                    private array $visited;
 
-                    /**
-                     * @param ObjectType[] $visited
-                     */
+                    /** @param ObjectType[] $visited */
                     public function __construct(array &$visited)
                     {
                         $this->visited = &$visited;
                     }
 
-                    public function visitObject(ObjectType $object) : void
+                    public function visitObject(ObjectType $object): void
                     {
                         TestCase::assertEquals('Query', $object->name);
                         $this->visited[] = $object;
@@ -1659,10 +1577,8 @@ class DirectivesTest extends TestCase
         }
     }
 
-    /**
-     * @see it('allows multiple directives when first replaces type (issue #851)')
-     */
-    public function testAllowsMultipleDirectivesWhenFirstReplacesType() : void
+    /** @see it('allows multiple directives when first replaces type (issue #851)') */
+    public function testAllowsMultipleDirectivesWhenFirstReplacesType(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => '
@@ -1675,10 +1591,8 @@ class DirectivesTest extends TestCase
             'schemaDirectives' => [
                 'upper' => new class extends SchemaDirectiveVisitor
                 {
-                    /**
-                     * @param mixed[] $details
-                     */
-                    public function visitFieldDefinition(FieldDefinition $field, array $details) : FieldDefinition
+                    /** @param mixed[] $details */
+                    public function visitFieldDefinition(FieldDefinition $field, array $details): FieldDefinition
                     {
                         $resolve = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
 
@@ -1688,6 +1602,7 @@ class DirectivesTest extends TestCase
                             if (is_string($result)) {
                                 return strtoupper($result);
                             }
+
                             return $result;
                         };
 
@@ -1696,10 +1611,8 @@ class DirectivesTest extends TestCase
                 },
                 'reverse' => new class extends SchemaDirectiveVisitor
                 {
-                    /**
-                     * @param mixed[] $details
-                     */
-                    public function visitFieldDefinition(FieldDefinition $field, array $details) : void
+                    /** @param mixed[] $details */
+                    public function visitFieldDefinition(FieldDefinition $field, array $details): void
                     {
                         $resolve          = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
                         $field->resolveFn = static function (...$args) use ($resolve) {
@@ -1728,12 +1641,12 @@ class DirectivesTest extends TestCase
                 query {
                     hello
                 }
-            '
+            ',
         );
 
         static::assertEquals(
             ['hello' => 'DLROW OLLEH'],
-            $result->data
+            $result->data,
         );
     }
 }

--- a/tests/DirectivesTest.php
+++ b/tests/DirectivesTest.php
@@ -249,11 +249,13 @@ class DirectivesTest extends TestCase
                         $this->visitCount = &$visitCount;
                     }
 
-                    public function visitObject(ObjectType $object): void
+                    public function visitObject(ObjectType $object): mixed
                     {
                         $this->visited[] = $object;
 
                         $this->visitCount++;
+
+                        return null;
                     }
                 },
             ],
@@ -319,18 +321,20 @@ class DirectivesTest extends TestCase
             [
                 'mutationTypeDirective' => new class ($mutationObjectType) extends SchemaDirectiveVisitor
                 {
-                    private ObjectType $mutationObjectType;
+                    private ObjectType|null $mutationObjectType;
 
                     public function __construct(ObjectType|null &$mutationObjectType)
                     {
                         $this->mutationObjectType = &$mutationObjectType;
                     }
 
-                    public function visitObject(ObjectType $object): void
+                    public function visitObject(ObjectType $object): mixed
                     {
                         $this->mutationObjectType = $object;
                         TestCase::assertEquals($object, $this->visitedType);
                         TestCase::assertEquals('Mutation', $object->name);
+
+                        return null;
                     }
                 },
                 'mutationMethodDirective' => new class (
@@ -338,8 +342,8 @@ class DirectivesTest extends TestCase
                     $mutationField
                 ) extends SchemaDirectiveVisitor
                 {
-                    private ObjectType $mutationObjectType;
-                    private FieldDefinition $mutationField;
+                    private ObjectType|null $mutationObjectType;
+                    private FieldDefinition|null $mutationField;
 
                     public function __construct(ObjectType|null &$mutationObjectType, FieldDefinition|null &$mutationField)
                     {
@@ -348,7 +352,7 @@ class DirectivesTest extends TestCase
                     }
 
                     /** @param mixed[] $details */
-                    public function visitFieldDefinition(FieldDefinition $field, array $details): void
+                    public function visitFieldDefinition(FieldDefinition $field, array $details): mixed
                     {
                         TestCase::assertEquals($field, $this->visitedType);
                         TestCase::assertEquals('addPerson', $field->name);
@@ -356,6 +360,8 @@ class DirectivesTest extends TestCase
                         TestCase::assertEquals(1, count($field->args));
 
                         $this->mutationField = $field;
+
+                        return null;
                     }
                 },
                 'mutationArgumentDirective' => new class (
@@ -363,8 +369,8 @@ class DirectivesTest extends TestCase
                     $mutationField
                 ) extends SchemaDirectiveVisitor
                 {
-                    private ObjectType $mutationObjectType;
-                    private FieldDefinition $mutationField;
+                    private ObjectType|null $mutationObjectType;
+                    private FieldDefinition|null $mutationField;
 
                     public function __construct(ObjectType|null &$mutationObjectType, FieldDefinition|null &$mutationField)
                     {
@@ -373,34 +379,38 @@ class DirectivesTest extends TestCase
                     }
 
                     /** @param mixed[] $details */
-                    public function visitArgumentDefinition(FieldArgument $arg, array $details): void
+                    public function visitArgumentDefinition(FieldArgument $arg, array $details): mixed
                     {
                         TestCase::assertEquals($arg, $this->visitedType);
                         TestCase::assertEquals('input', $arg->name);
                         TestCase::assertEquals($this->mutationField, $details['field']);
                         TestCase::assertEquals($this->mutationObjectType, $details['objectType']);
                         TestCase::assertEquals($arg, $details['field']->args[0]);
+
+                        return null;
                     }
                 },
                 'enumTypeDirective' => new class ($enumObjectType) extends SchemaDirectiveVisitor
                 {
-                    private EnumType $enumObjectType;
+                    private EnumType|null $enumObjectType;
 
                     public function __construct(EnumType|null &$enumObjectType)
                     {
                         $this->enumObjectType = &$enumObjectType;
                     }
 
-                    public function visitEnum(EnumType $enumType): void
+                    public function visitEnum(EnumType $enumType): mixed
                     {
                         TestCase::assertEquals($enumType, $this->visitedType);
                         TestCase::assertEquals('Gender', $enumType->name);
                         $this->enumObjectType = $enumType;
+
+                        return null;
                     }
                 },
                 'enumValueDirective' => new class ($enumObjectType) extends SchemaDirectiveVisitor
                 {
-                    private EnumType $enumObjectType;
+                    private EnumType|null $enumObjectType;
 
                     public function __construct(EnumType|null &$enumObjectType)
                     {
@@ -414,27 +424,31 @@ class DirectivesTest extends TestCase
                         TestCase::assertEquals('NONBINARY', $value->name);
                         TestCase::assertEquals('NONBINARY', $value->value);
                         TestCase::assertEquals($this->enumObjectType, $details['enumType']);
+
+                        return null;
                     }
                 },
                 'inputTypeDirective' => new class ($inputObjectType) extends SchemaDirectiveVisitor
                 {
-                    private InputObjectType $inputObjectType;
+                    private InputObjectType|null $inputObjectType;
 
                     public function __construct(InputObjectType|null &$inputObjectType)
                     {
                         $this->inputObjectType = &$inputObjectType;
                     }
 
-                    public function visitInputObject(InputObjectType $object): void
+                    public function visitInputObject(InputObjectType $object): mixed
                     {
                         $this->inputObjectType = $object;
                         TestCase::assertEquals($object, $this->visitedType);
                         TestCase::assertEquals('PersonInput', $object->name);
+
+                        return null;
                     }
                 },
                 'inputFieldDirective' => new class ($inputObjectType) extends SchemaDirectiveVisitor
                 {
-                    private InputObjectType $inputObjectType;
+                    private InputObjectType|null $inputObjectType;
 
                     public function __construct(InputObjectType|null &$inputObjectType)
                     {
@@ -442,11 +456,13 @@ class DirectivesTest extends TestCase
                     }
 
                     /** @param mixed[] $details */
-                    public function visitInputFieldDefinition(InputObjectField $field, array $details): void
+                    public function visitInputFieldDefinition(InputObjectField $field, array $details): mixed
                     {
                         TestCase::assertEquals($field, $this->visitedType);
                         TestCase::assertEquals('name', $field->name);
                         TestCase::assertEquals($this->inputObjectType, $details['objectType']);
+
+                        return null;
                     }
                 },
             ],
@@ -508,10 +524,12 @@ class DirectivesTest extends TestCase
                 );
             }
 
-            public function visitObject(ObjectType $object): void
+            public function visitObject(ObjectType $object): mixed
             {
                 TestCase::assertEquals($object, $this->schema->getType($object->name));
                 $this->names[] = $object->name;
+
+                return null;
             }
         };
 
@@ -653,14 +671,16 @@ class DirectivesTest extends TestCase
                 return $prev;
             }
 
-            public function visitObject(ObjectType $object): void
+            public function visitObject(ObjectType $object): mixed
             {
                 ++$this->context->objectCount;
                 TestCase::assertEquals(3, $this->args['times']);
+
+                return null;
             }
 
             /** @param mixed[] $details */
-            public function visitFieldDefinition(FieldDefinition $field, array $details): void
+            public function visitFieldDefinition(FieldDefinition $field, array $details): mixed
             {
                 ++$this->context->fieldCount;
                 if ($field->name === 'judge') {
@@ -672,6 +692,8 @@ class DirectivesTest extends TestCase
                 }
 
                 TestCase::assertEquals('IMPARTIAL', $this->args['party']);
+
+                return null;
             }
         };
 
@@ -709,7 +731,7 @@ class DirectivesTest extends TestCase
                 'upper' => new class extends SchemaDirectiveVisitor
                 {
                     /** @param mixed[] $detail */
-                    public function visitFieldDefinition(FieldDefinition $field, array $detail): void
+                    public function visitFieldDefinition(FieldDefinition $field, array $detail): mixed
                     {
                         $resolve          = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
                         $field->resolveFn = static function (...$args) use ($resolve) {
@@ -720,6 +742,8 @@ class DirectivesTest extends TestCase
 
                             return $result;
                         };
+
+                        return null;
                     }
                 },
             ],
@@ -759,7 +783,7 @@ class DirectivesTest extends TestCase
                 'date' => new class extends SchemaDirectiveVisitor
                 {
                     /** @param mixed[] $detail */
-                    public function visitFieldDefinition(FieldDefinition $field, array $detail): void
+                    public function visitFieldDefinition(FieldDefinition $field, array $detail): mixed
                     {
                         $resolve = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
                         $format  = $this->args['format'];
@@ -771,6 +795,8 @@ class DirectivesTest extends TestCase
 
                             return DateTime::createFromFormat(DateTime::ATOM, $date)->format($format);
                         };
+
+                        return null;
                     }
                 },
             ],
@@ -800,7 +826,7 @@ class DirectivesTest extends TestCase
         $formattableDateDirective = new class extends SchemaDirectiveVisitor
         {
             /** @param mixed[] $detail */
-            public function visitFieldDefinition(FieldDefinition $field, array $detail): void
+            public function visitFieldDefinition(FieldDefinition $field, array $detail): mixed
             {
                 $resolve       = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
                 $defaultFormat = $this->args['defaultFormat'];
@@ -817,6 +843,8 @@ class DirectivesTest extends TestCase
 
                     return $date->format($format);
                 };
+
+                return null;
             }
         };
 
@@ -899,7 +927,7 @@ class DirectivesTest extends TestCase
                     }
 
                     /** @param mixed[] $details */
-                    public function visitFieldDefinition(FieldDefinition $field, array $details): void
+                    public function visitFieldDefinition(FieldDefinition $field, array $details): mixed
                     {
                         $resolve          = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
                         $field->resolveFn = function (...$args) use ($resolve, $details, $field) {
@@ -911,6 +939,8 @@ class DirectivesTest extends TestCase
 
                             return $translate($defaultText, $path, $this->ctx['locale']);
                         };
+
+                        return null;
                     }
                 },
             ],
@@ -974,10 +1004,12 @@ class DirectivesTest extends TestCase
                 $this->getUser = $getUser;
             }
 
-            public function visitObject(ObjectType $type): void
+            public function visitObject(ObjectType $type): mixed
             {
                 $this->ensureFieldsWrapped($type);
                 $type->_requiredAuthRole = $this->args['requires'];
+
+                return null;
             }
 
             // Visitor methods for nested types like fields and arguments
@@ -985,10 +1017,12 @@ class DirectivesTest extends TestCase
             // the parent and grandparent types.
 
             /** @param mixed[] $details */
-            public function visitFieldDefinition(FieldDefinition $field, array $details): void
+            public function visitFieldDefinition(FieldDefinition $field, array $details): mixed
             {
                 $this->ensureFieldsWrapped($details['objectType']);
                 $field->_requiredAuthRole = $this->args['requires'];
+
+                return null;
             }
 
             public function ensureFieldsWrapped(ObjectType $objectType): void
@@ -1187,15 +1221,19 @@ class DirectivesTest extends TestCase
                     }
 
                     /** @param mixed[] $details */
-                    public function visitInputFieldDefinition(InputObjectField $field, array $details): void
+                    public function visitInputFieldDefinition(InputObjectField $field, array $details): mixed
                     {
                         $this->wrapType($field);
+
+                        return null;
                     }
 
                     /** @param mixed[] $details */
-                    public function visitFieldDefinition(FieldDefinition $field, array $details): void
+                    public function visitFieldDefinition(FieldDefinition $field, array $details): mixed
                     {
                         $this->wrapType($field);
+
+                        return null;
                     }
 
                     private function wrapType(FieldDefinition|InputObjectField $field): void
@@ -1302,7 +1340,7 @@ class DirectivesTest extends TestCase
             'schemaDirectives' => [
                 'uniqueID' => new class extends SchemaDirectiveVisitor
                 {
-                    public function visitObject(ObjectType $type): void
+                    public function visitObject(ObjectType $type): mixed
                     {
                         ['name' => $name, 'from' => $from] = $this->args;
                         $fields                            = $type->getFields();
@@ -1321,6 +1359,8 @@ class DirectivesTest extends TestCase
                             },
                         ]);
                         Utils::forceSet($type, 'fields', $fields);
+
+                        return null;
                     }
                 },
             ],
@@ -1392,25 +1432,25 @@ class DirectivesTest extends TestCase
     /** @see it('automatically updates references to changed types') */
     public function testAutomaticallyUpdatesReferencesToChangedTypes(): void
     {
-        $HumanType = null;
+        $humanType = null;
         $schema    = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->typeDefs,
             'schemaDirectives' => [
-                'objectTypeDirective' => new class ($HumanType) extends SchemaDirectiveVisitor
+                'objectTypeDirective' => new class ($humanType) extends SchemaDirectiveVisitor
                 {
-                    private ObjectType $HumanType;
+                    private ObjectType|null $humanType;
 
                     public function __construct(ObjectType|null &$HumanType)
                     {
-                        $this->HumanType = &$HumanType;
+                        $this->humanType = &$HumanType;
                     }
 
                     public function visitObject(ObjectType $object): ObjectType
                     {
-                        $this->HumanType       = clone $object;
-                        $this->HumanType->name = 'Human';
+                        $this->humanType       = clone $object;
+                        $this->humanType->name = 'Human';
 
-                        return $this->HumanType;
+                        return $this->humanType;
                     }
                 },
             ],
@@ -1423,11 +1463,11 @@ class DirectivesTest extends TestCase
             throw new Exception('Query.people not a GraphQLList type');
         }
 
-        static::assertEquals($HumanType, $peopleType->ofType);
+        static::assertEquals($humanType, $peopleType->ofType);
 
         $Mutation            = $schema->getMutationType();
         $addPersonResultType = $Mutation->getField('addPerson')->getType();
-        static::assertEquals($HumanType, $addPersonResultType);
+        static::assertEquals($humanType, $addPersonResultType);
 
         $WhateverUnion = $schema->getType('WhateverUnion');
 
@@ -1437,7 +1477,7 @@ class DirectivesTest extends TestCase
                 continue;
             }
 
-            static::assertEquals($HumanType, $type);
+            static::assertEquals($humanType, $type);
             $found = true;
         }
 
@@ -1515,28 +1555,30 @@ class DirectivesTest extends TestCase
             'schemaDirectives' => [
                 'rename' => new class extends SchemaDirectiveVisitor
                 {
-                    public function visitObject(ObjectType $object): void
+                    public function visitObject(ObjectType $object): mixed
                     {
                         $object->name = $this->args['to'];
+
+                        return null;
                     }
                 },
             ],
         ]);
 
-        $Human = $schema->getType('Human');
-        assert($Human instanceof ObjectType);
-        static::assertEquals('Human', $Human->name);
-        static::assertEquals(Type::int(), $Human->getField('heightInInches')->getType());
+        $human = $schema->getType('Human');
+        assert($human instanceof ObjectType);
+        static::assertEquals('Human', $human->name);
+        static::assertEquals(Type::int(), $human->getField('heightInInches')->getType());
 
-        $Person = $schema->getType('Person');
-        assert($Person instanceof ObjectType);
-        static::assertEquals('Person', $Person->name);
-        static::assertEquals($schema->getType('Date'), $Person->getField('born')->getType());
+        $person = $schema->getType('Person');
+        assert($person instanceof ObjectType);
+        static::assertEquals('Person', $person->name);
+        static::assertEquals($schema->getType('Date'), $person->getField('born')->getType());
 
-        $Query      = $schema->getQueryType();
-        $peopleType = $Query->getField('people')->getType();
+        $query      = $schema->getQueryType();
+        $peopleType = $query->getField('people')->getType();
         assert($peopleType instanceof ListOfType);
-        static::assertEquals($Human, $peopleType->ofType);
+        static::assertEquals($human, $peopleType->ofType);
     }
 
     /** @see it('does not enforce query directive locations (issue #680)') */
@@ -1562,10 +1604,12 @@ class DirectivesTest extends TestCase
                         $this->visited = &$visited;
                     }
 
-                    public function visitObject(ObjectType $object): void
+                    public function visitObject(ObjectType $object): mixed
                     {
                         TestCase::assertEquals('Query', $object->name);
                         $this->visited[] = $object;
+
+                        return null;
                     }
                 },
             ],
@@ -1612,7 +1656,7 @@ class DirectivesTest extends TestCase
                 'reverse' => new class extends SchemaDirectiveVisitor
                 {
                     /** @param mixed[] $details */
-                    public function visitFieldDefinition(FieldDefinition $field, array $details): void
+                    public function visitFieldDefinition(FieldDefinition $field, array $details): mixed
                     {
                         $resolve          = $field->resolveFn ?? [Executor::class, 'defaultFieldResolver'];
                         $field->resolveFn = static function (...$args) use ($resolve) {
@@ -1623,6 +1667,8 @@ class DirectivesTest extends TestCase
 
                             return $result;
                         };
+
+                        return null;
                     }
                 },
             ],

--- a/tests/ErrorWithExtensions.php
+++ b/tests/ErrorWithExtensions.php
@@ -10,6 +10,6 @@ class ErrorWithExtensions extends Error
 {
     public function __construct(string $message, string $code)
     {
-        parent::__construct($message, null, null, null, null, null, ['code' => $code]);
+        parent::__construct($message, null, null, [], null, null, ['code' => $code]);
     }
 }

--- a/tests/ErrorWithResult.php
+++ b/tests/ErrorWithResult.php
@@ -8,15 +8,8 @@ use GraphQL\Error\Error;
 
 class ErrorWithResult extends Error
 {
-    /** @var mixed */
-    public $result;
-
-    /**
-     * @param mixed $result
-     */
-    public function __construct(string $message, $result)
+    public function __construct(string $message, public mixed $result)
     {
         parent::__construct($message);
-        $this->result = $result;
     }
 }

--- a/tests/ErrorsTest.php
+++ b/tests/ErrorsTest.php
@@ -8,14 +8,13 @@ use GraphQL\Error\Error;
 use GraphQL\Executor\ExecutionResult;
 use GraphQLTools\Stitching\Errors;
 use PHPUnit\Framework\TestCase;
+
 use function count;
 
 class ErrorsTest extends TestCase
 {
-    /**
-     * @see it('should return OWN error kind if path is not defined')
-     */
-    public function testShouldReturnOWNErrorKindIfPathIsNotDefined() : void
+    /** @see it('should return OWN error kind if path is not defined') */
+    public function testShouldReturnOWNErrorKindIfPathIsNotDefined(): void
     {
         $mockErrors = [
             'responseKey' => '',
@@ -29,18 +28,16 @@ class ErrorsTest extends TestCase
             [
                 'kind' => 'OWN',
                 'error' => $mockErrors[Errors::ERROR_SYMBOL][0],
-            ]
+            ],
         );
     }
 
-    /**
-     * @see it('persists single error with a result')
-     */
-    public function testPersistsSingleErrorWithAResult() : void
+    /** @see it('persists single error with a result') */
+    public function testPersistsSingleErrorWithAResult(): void
     {
         $result = new ExecutionResult(
             null,
-            [new ErrorWithResult('Test error', 'result')]
+            [new ErrorWithResult('Test error', 'result')],
         );
 
         try {
@@ -51,14 +48,12 @@ class ErrorsTest extends TestCase
         }
     }
 
-    /**
-     * @see it('persists single error with extensions')
-     */
-    public function testPersistsSingleErrorWithExtensions() : void
+    /** @see it('persists single error with extensions') */
+    public function testPersistsSingleErrorWithExtensions(): void
     {
         $result = new ExecutionResult(
             null,
-            [new ErrorWithExtensions('Test error', 'UNAUTHENTICATED')]
+            [new ErrorWithExtensions('Test error', 'UNAUTHENTICATED')],
         );
 
         try {
@@ -70,14 +65,12 @@ class ErrorsTest extends TestCase
         }
     }
 
-    /**
-     * @see it('persists original errors without a result')
-     */
-    public function testPersistsOriginalErrorsWithoutAResult() : void
+    /** @see it('persists original errors without a result') */
+    public function testPersistsOriginalErrorsWithoutAResult(): void
     {
         $result = new ExecutionResult(
             null,
-            [new Error('Test error')]
+            [new Error('Test error')],
         );
 
         try {
@@ -94,17 +87,15 @@ class ErrorsTest extends TestCase
         }
     }
 
-    /**
-     * @see it('combines errors and persists the original errors')
-     */
-    public function testCombinesErrorsAndPersistsTheOriginalErrors() : void
+    /** @see it('combines errors and persists the original errors') */
+    public function testCombinesErrorsAndPersistsTheOriginalErrors(): void
     {
         $result = new ExecutionResult(
             null,
             [
                 new Error('Error1'),
                 new Error('Error2'),
-            ]
+            ],
         );
 
         try {

--- a/tests/ExtensionExtractionTest.php
+++ b/tests/ExtensionExtractionTest.php
@@ -10,10 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 class ExtensionExtractionTest extends TestCase
 {
-    /**
-     * @see it('extracts extended inputs')
-     */
-    public function testExtractsExtendedInputs() : void
+    /** @see it('extracts extended inputs') */
+    public function testExtractsExtendedInputs(): void
     {
         $typeDefs = '
             input Input {
@@ -32,10 +30,8 @@ class ExtensionExtractionTest extends TestCase
         static::assertEquals('InputObjectTypeExtension', $extensionAst->definitions[0]->kind);
     }
 
-    /**
-     * @see it('extracts extended unions')
-     */
-    public function testExtractsExtendedUnions() : void
+    /** @see it('extracts extended unions') */
+    public function testExtractsExtendedUnions(): void
     {
         $typeDefs = '
             type Person {
@@ -58,10 +54,8 @@ class ExtensionExtractionTest extends TestCase
         static::assertEquals('UnionTypeExtension', $extensionAst->definitions[0]->kind);
     }
 
-    /**
-     * @see it('extracts extended enums')
-     */
-    public function testExtractsExtendedEnums() : void
+    /** @see it('extracts extended enums') */
+    public function testExtractsExtendedEnums(): void
     {
         $typeDefs = '
             enum Color {

--- a/tests/FragmentsAreNotDuplicatedTest.php
+++ b/tests/FragmentsAreNotDuplicatedTest.php
@@ -12,14 +12,12 @@ use PHPUnit\Framework\TestCase;
 
 class FragmentsAreNotDuplicatedTest extends TestCase
 {
-    /** @var string */
-    protected $rawSchema;
-    /** @var string */
-    protected $query;
+    protected string $rawSchema;
+    protected string $query;
     /** @var mixed[] */
-    protected $variables;
+    protected array $variables;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -65,7 +63,7 @@ class FragmentsAreNotDuplicatedTest extends TestCase
         $this->variables = ['id' => 123];
     }
 
-    private static function assertNoDuplicateFragmentErrors(ExecutionResult $result) : void
+    private static function assertNoDuplicateFragmentErrors(ExecutionResult $result): void
     {
         // Run assertion against each array element for better test failure output.
 
@@ -74,10 +72,8 @@ class FragmentsAreNotDuplicatedTest extends TestCase
         }
     }
 
-    /**
-     * @see it('should not throw `There can be only one fragment named "FieldName"` errors')
-     */
-    public function testShouldNotThrowThereCanBeOnlyOneFragmentNamedFieldNameErrors() : void
+    /** @see it('should not throw `There can be only one fragment named "FieldName"` errors') */
+    public function testShouldNotThrowThereCanBeOnlyOneFragmentNamedFieldNameErrors(): void
     {
         $originalSchema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->rawSchema,

--- a/tests/GraphQLTypeJSON.php
+++ b/tests/GraphQLTypeJSON.php
@@ -14,45 +14,50 @@ use GraphQL\Language\AST\ObjectValueNode;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Language\AST\VariableNode;
 use GraphQL\Type\Definition\CustomScalarType;
+
 use function array_map;
 
 class GraphQLTypeJSON
 {
-    /**
-     * @param mixed[] $variables
-     *
-     * @return mixed
-     */
-    protected static function parseLiteral(Node $ast, array $variables)
+    /** @param mixed[] $variables */
+    protected static function parseLiteral(Node $ast, array $variables): mixed
     {
         switch (true) {
             case $ast instanceof StringValueNode:
             case $ast instanceof BooleanValueNode:
                 return $ast->value;
+
             case $ast instanceof IntValueNode:
             case $ast instanceof FloatValueNode:
                 return (float) $ast->value;
+
             case $ast instanceof ObjectValueNode:
                 $value = [];
                 foreach ($ast->fields as $field) {
                     $value[$field->name->value] = static::parseLiteral($field->value, $variables);
                 }
+
                 return $value;
+
             case $ast instanceof ListValueNode:
                 return array_map(static function ($n) use ($variables) {
                     return static::parseLiteral($n, $variables);
                 }, $ast->values);
+
             case $ast instanceof NullValueNode:
                 return null;
+
             case $ast instanceof VariableNode:
                 $name = $ast->name->value;
+
                 return $variables[$name] ?? null;
+
             default:
                 return null;
         }
     }
 
-    public static function build() : CustomScalarType
+    public static function build(): CustomScalarType
     {
         return new CustomScalarType([
             'name' => 'JSON',

--- a/tests/MockingTest.php
+++ b/tests/MockingTest.php
@@ -15,6 +15,7 @@ use GraphQLTools\Mock;
 use GraphQLTools\SimpleLogger;
 use PHPUnit\Framework\TestCase;
 use Throwable;
+
 use function count;
 use function explode;
 use function in_array;
@@ -25,14 +26,14 @@ use function strtolower;
 
 class MockingTest extends TestCase
 {
-    /** @var string */
-    protected $shorthand;
+    protected string $shorthand;
     /** @var mixed[] */
-    protected $resolveFunctions;
+    protected array $resolveFunctions;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
+
         $this->shorthand        = '
             scalar MissingMockType
             interface Flying {
@@ -88,22 +89,20 @@ class MockingTest extends TestCase
         ';
         $this->resolveFunctions = [
             'BirdsAndBees' => [
-                '__resolveType' => static function ($data, $context, ResolveInfo $info) : Type {
+                '__resolveType' => static function ($data, $context, ResolveInfo $info): Type {
                     return $info->schema->getType($data['__typename']);
                 },
             ],
             'Flying' => [
-                '__resolveType' => static function ($data, $context, ResolveInfo $info) : Type {
+                '__resolveType' => static function ($data, $context, ResolveInfo $info): Type {
                     return $info->schema->getType($data['__typename']);
                 },
             ],
         ];
     }
 
-    /**
-     * @see it('throws an error if you forget to pass schema')
-     */
-    public function testThrowsAnErrorIfYouForgetToPassSchema() : void
+    /** @see it('throws an error if you forget to pass schema') */
+    public function testThrowsAnErrorIfYouForgetToPassSchema(): void
     {
         try {
             Mock::addMockFunctionsToSchema([]);
@@ -113,10 +112,8 @@ class MockingTest extends TestCase
         }
     }
 
-    /**
-     * @see it('throws an error if the property "schema" on the first argument is not of type GraphQLSchema')
-     */
-    public function testThrowsAnErrorIfThePropertySchemaOnThFirstArgumentIsNotOfTypeSchema() : void
+    /** @see it('throws an error if the property "schema" on the first argument is not of type GraphQLSchema') */
+    public function testThrowsAnErrorIfThePropertySchemaOnThFirstArgumentIsNotOfTypeSchema(): void
     {
         try {
             Mock::addMockFunctionsToSchema(['schema' => ['']]);
@@ -126,10 +123,8 @@ class MockingTest extends TestCase
         }
     }
 
-    /**
-     * @see it('throws an error if second argument is not a Map')
-     */
-    public function testThrowsAnErrorIfSecondArgumentIsNotAMap() : void
+    /** @see it('throws an error if second argument is not a Map') */
+    public function testThrowsAnErrorIfSecondArgumentIsNotAMap(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         try {
@@ -140,10 +135,8 @@ class MockingTest extends TestCase
         }
     }
 
-    /**
-     * @see it('throws an error if mockFunctionMap contains a non-function thingy')
-     */
-    public function testThrowsAnErrorIfMockFunctionMapContainsANonFunctionThingy() : void
+    /** @see it('throws an error if mockFunctionMap contains a non-function thingy') */
+    public function testThrowsAnErrorIfMockFunctionMapContainsANonFunctionThingy(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = ['Int' => 55];
@@ -155,10 +148,8 @@ class MockingTest extends TestCase
         }
     }
 
-    /**
-     * @see it('mocks the default types for you')
-     */
-    public function testMocksTheDefaultTypesForYou() : void
+    /** @see it('mocks the default types for you') */
+    public function testMocksTheDefaultTypesForYou(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [];
@@ -180,10 +171,8 @@ class MockingTest extends TestCase
         static::assertTrue(is_string($res->data['returnID']));
     }
 
-    /**
-     * @see it('lets you use mockServer for convenience')
-     */
-    public function testLetsYouUseMockServerForConvenience() : void
+    /** @see it('lets you use mockServer for convenience') */
+    public function testLetsYouUseMockServerForConvenience(): void
     {
         $testQuery = '
             {
@@ -240,10 +229,8 @@ class MockingTest extends TestCase
         static::assertEquals(54321, $res->data['returnBirdsAndBees'][1]['returnInt']);
     }
 
-    /**
-     * @see it('mockServer is able to preserveResolvers of a prebuilt schema')
-     */
-    public function testMockServerIsAbleToPreserveResolversOfAPrebuiltSchema() : void
+    /** @see it('mockServer is able to preserveResolvers of a prebuilt schema') */
+    public function testMockServerIsAbleToPreserveResolversOfAPrebuiltSchema(): void
     {
         $jsSchema  = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $resolvers = [
@@ -257,7 +244,7 @@ class MockingTest extends TestCase
         GraphQLTools::addResolveFunctionsToSchema(
             $jsSchema,
             $resolvers,
-            ['requireResolversForResolveType' => false]
+            ['requireResolversForResolveType' => false],
         );
 
         $testQuery = '
@@ -303,10 +290,8 @@ class MockingTest extends TestCase
         static::assertEquals(54321, $res->data['returnBirdsAndBees'][1]['returnInt']);
     }
 
-    /**
-     * @see it('lets you use mockServer with prebuilt schema')
-     */
-    public function testLetsYouUseMockServerWithPrebuiltSchema() : void
+    /** @see it('lets you use mockServer with prebuilt schema') */
+    public function testLetsYouUseMockServerWithPrebuiltSchema(): void
     {
         $jsSchema  = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $testQuery = '
@@ -361,10 +346,8 @@ class MockingTest extends TestCase
         static::assertEquals(54321, $res->data['returnBirdsAndBees'][1]['returnInt']);
     }
 
-    /**
-     * @see it('does not mask resolveType functions if you tell it not to')
-     */
-    public function testDoesNotMaskResolveTypeFunctionsIfYouTellItNotTo() : void
+    /** @see it('does not mask resolveType functions if you tell it not to') */
+    public function testDoesNotMaskResolveTypeFunctionsIfYouTellItNotTo(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $spy      = 0;
@@ -373,6 +356,7 @@ class MockingTest extends TestCase
             'BirdsAndBees' => [
                 '__resolveType' => static function ($data, $context, ResolveInfo $info) use (&$spy) {
                     ++$spy;
+
                     return $info->schema->getType($data['__typename']);
                 },
             ],
@@ -381,7 +365,7 @@ class MockingTest extends TestCase
         GraphQLTools::addResolveFunctionsToSchema(
             $jsSchema,
             $resolvers,
-            ['requireResolversForResolveType' => false]
+            ['requireResolversForResolveType' => false],
         );
 
         Mock::addMockFunctionsToSchema([
@@ -407,10 +391,8 @@ class MockingTest extends TestCase
         static::assertEquals(2, $spy);
     }
 
-    /**
-     * @see it('can mock Enum')
-     */
-    public function testCanMockEnum() : void
+    /** @see it('can mock Enum') */
+    public function testCanMockEnum(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [];
@@ -420,10 +402,8 @@ class MockingTest extends TestCase
         static::assertTrue(in_array($res->data['returnEnum'], ['A', 'B', 'C']));
     }
 
-    /**
-     * @see it('can mock Unions')
-     */
-    public function testCanMockUnions() : void
+    /** @see it('can mock Unions') */
+    public function testCanMockUnions(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         GraphQLTools::addResolveFunctionsToSchema($jsSchema, $this->resolveFunctions);
@@ -484,10 +464,8 @@ class MockingTest extends TestCase
         static::assertTrue($foundBee);
     }
 
-    /**
-     * @see it('can mock Interfaces by default')
-     */
-    public function testCanMockInterfacesByDefault() : void
+    /** @see it('can mock Interfaces by default') */
+    public function testCanMockInterfacesByDefault(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         GraphQLTools::addResolveFunctionsToSchema($jsSchema, $this->resolveFunctions);
@@ -555,10 +533,8 @@ class MockingTest extends TestCase
         static::assertTrue($foundB);
     }
 
-    /**
-     * @see it('can support explicit Interface mock')
-     */
-    public function testCanSupportExplicitInterfaceMock() : void
+    /** @see it('can support explicit Interface mock') */
+    public function testCanSupportExplicitInterfaceMock(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         GraphQLTools::addResolveFunctionsToSchema($jsSchema, $this->resolveFunctions);
@@ -613,10 +589,8 @@ class MockingTest extends TestCase
         ], $res->data['node']);
     }
 
-    /**
-     * @see it('can support explicit UnionType mock')
-     */
-    public function testCanSupportExplicitUnionTypeMock() : void
+    /** @see it('can support explicit UnionType mock') */
+    public function testCanSupportExplicitUnionTypeMock(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         GraphQLTools::addResolveFunctionsToSchema($jsSchema, $this->resolveFunctions);
@@ -672,10 +646,8 @@ class MockingTest extends TestCase
         ], $res->data['node2']);
     }
 
-    /**
-     * @see it('throws an error when __typename is not returned within an explicit interface mock')
-     */
-    public function testThrowsAnErrorWhenTypenameIsNotReturnedWithinAnExplicitInterfaceMock() : void
+    /** @see it('throws an error when __typename is not returned within an explicit interface mock') */
+    public function testThrowsAnErrorWhenTypenameIsNotReturnedWithinAnExplicitInterfaceMock(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         GraphQLTools::addResolveFunctionsToSchema($jsSchema, $this->resolveFunctions);
@@ -693,7 +665,7 @@ class MockingTest extends TestCase
                     'returnInt' => 'A',
                 ];
             },
-            'Flying' => static function ($root, $args) : void {
+            'Flying' => static function ($root, $args): void {
             },
         ];
 
@@ -710,10 +682,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->errors[0]->getPrevious()->getMessage());
     }
 
-    /**
-     * @see it('throws an error in resolve if mock type is not defined')
-     */
-    public function testThrowsAnErrorInResolveIfMockTypeIsNotDefined() : void
+    /** @see it('throws an error in resolve if mock type is not defined') */
+    public function testThrowsAnErrorInResolveIfMockTypeIsNotDefined(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [];
@@ -726,10 +696,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->errors[0]->getPrevious()->getMessage());
     }
 
-    /**
-     * @see it('throws an error in resolve if mock type is not defined and resolver failed')
-     */
-    public function testThrowsAnErrorInResolveIfMockTypeIsNotDefinedAndResolverFailed() : void
+    /** @see it('throws an error in resolve if mock type is not defined and resolver failed') */
+    public function testThrowsAnErrorInResolveIfMockTypeIsNotDefinedAndResolverFailed(): void
     {
         $jsSchema  = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $resolvers = [
@@ -754,7 +722,7 @@ class MockingTest extends TestCase
         GraphQLTools::addResolveFunctionsToSchema(
             $jsSchema,
             $resolvers,
-            ['requireResolversForResolveType' => false]
+            ['requireResolversForResolveType' => false],
         );
 
         $mockMap = [];
@@ -772,10 +740,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->errors[0]->getPrevious()->getMessage());
     }
 
-    /**
-     * @see it('can preserve scalar resolvers')
-     */
-    public function testCanPreserveScalarResolvers() : void
+    /** @see it('can preserve scalar resolvers') */
+    public function testCanPreserveScalarResolvers(): void
     {
         $jsSchema  = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $resolvers = [
@@ -800,7 +766,7 @@ class MockingTest extends TestCase
         GraphQLTools::addResolveFunctionsToSchema(
             $jsSchema,
             $resolvers,
-            ['requireResolversForResolveType' => false]
+            ['requireResolversForResolveType' => false],
         );
 
         $mockMap = [];
@@ -821,10 +787,8 @@ class MockingTest extends TestCase
         static::assertEmpty($res->errors);
     }
 
-    /**
-     * @see it('can mock an Int')
-     */
-    public function testCanMockAnInt() : void
+    /** @see it('can mock an Int') */
+    public function testCanMockAnInt(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -840,10 +804,8 @@ class MockingTest extends TestCase
         static::assertEquals(55, $res->data['returnInt']);
     }
 
-    /**
-     * @see it('can mock a Float')
-     */
-    public function testCanMockAFloat() : void
+    /** @see it('can mock a Float') */
+    public function testCanMockAFloat(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -859,10 +821,8 @@ class MockingTest extends TestCase
         static::assertEquals(55.5, $res->data['returnFloat']);
     }
 
-    /**
-     * @see it('can mock a Boolean')
-     */
-    public function testCanMockABoolean() : void
+    /** @see it('can mock a Boolean') */
+    public function testCanMockABoolean(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -878,10 +838,8 @@ class MockingTest extends TestCase
         static::assertTrue($res->data['returnBoolean']);
     }
 
-    /**
-     * @see it('can mock an ID')
-     */
-    public function testCanMockAnID() : void
+    /** @see it('can mock an ID') */
+    public function testCanMockAnID(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -897,10 +855,8 @@ class MockingTest extends TestCase
         static::assertEquals('ea5bdc19', $res->data['returnID']);
     }
 
-    /**
-     * @see it('nullable type is nullable'')
-     */
-    public function testNullableTypeIsNullable() : void
+    /** @see it('nullable type is nullable'') */
+    public function testNullableTypeIsNullable(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -916,10 +872,8 @@ class MockingTest extends TestCase
         static::assertNull($res->data['returnNullableString']);
     }
 
-    /**
-     * @see it('can mock a nonNull type')
-     */
-    public function testCanMockANonNullType() : void
+    /** @see it('can mock a nonNull type') */
+    public function testCanMockANonNullType(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -935,10 +889,8 @@ class MockingTest extends TestCase
         static::assertEquals('nonnull', $res->data['returnNonNullString']);
     }
 
-    /**
-     * @see it('nonNull type is not nullable')
-     */
-    public function testNonNullTypeIsNotNullable() : void
+    /** @see it('nonNull type is not nullable') */
+    public function testNonNullTypeIsNotNullable(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -955,10 +907,8 @@ class MockingTest extends TestCase
         static::assertCount(1, $res->errors);
     }
 
-    /**
-     * @see it('can mock object types')
-     */
-    public function testCanMockObjectTypes() : void
+    /** @see it('can mock object types') */
+    public function testCanMockObjectTypes(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -987,10 +937,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('can mock a list of ints')
-     */
-    public function testCanMockAListOfInts() : void
+    /** @see it('can mock a list of ints') */
+    public function testCanMockAListOfInts(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1010,10 +958,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('can mock a list of lists of objects')
-     */
-    public function testCanMocAListOfObjects() : void
+    /** @see it('can mock a list of lists of objects') */
+    public function testCanMocAListOfObjects(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1045,10 +991,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('does not mask resolve functions if you tell it not to')
-     */
-    public function testDoesNotMaskResolveFunctionsIfYouTellItNotTo() : void
+    /** @see it('does not mask resolve functions if you tell it not to') */
+    public function testDoesNotMaskResolveFunctionsIfYouTellItNotTo(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1086,7 +1030,7 @@ class MockingTest extends TestCase
         GraphQLTools::addResolveFunctionsToSchema(
             $jsSchema,
             $resolvers,
-            ['requireResolversForResolveType' => false]
+            ['requireResolversForResolveType' => false],
         );
 
         Mock::addMockFunctionsToSchema([
@@ -1108,15 +1052,13 @@ class MockingTest extends TestCase
         ];
 
         GraphQL::promiseToExecute(new ReactPromiseAdapter(), $jsSchema, $testQuery)
-            ->then(static function (ExecutionResult $res) use ($expected) : void {
+            ->then(static function (ExecutionResult $res) use ($expected): void {
                 static::assertEquals($expected, $res->data);
             });
     }
 
-    /**
-     * @see it('lets you mock non-leaf types conveniently')
-     */
-    public function testLetsYouMockNonLeafTypesConveniently() : void
+    /** @see it('lets you mock non-leaf types conveniently') */
+    public function testLetsYouMockNonLeafTypesConveniently(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1152,10 +1094,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('lets you mock and resolve non-leaf types concurrently')
-     */
-    public function testLetsYouMockAndResolveNonLeafTypesConcurrently() : void
+    /** @see it('lets you mock and resolve non-leaf types concurrently') */
+    public function testLetsYouMockAndResolveNonLeafTypesConcurrently(): void
     {
         $jsSchema  = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $resolvers = [
@@ -1173,7 +1113,7 @@ class MockingTest extends TestCase
         GraphQLTools::addResolveFunctionsToSchema(
             $jsSchema,
             $resolvers,
-            ['requireResolversForResolveType' => false]
+            ['requireResolversForResolveType' => false],
         );
 
         $mockMap = [
@@ -1213,10 +1153,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('lets you mock and resolve non-leaf types concurrently, support promises')
-     */
-    public function testLetsYouMockAndResolveNonLeafTypesConcurrentlySupportPromises() : void
+    /** @see it('lets you mock and resolve non-leaf types concurrently, support promises') */
+    public function testLetsYouMockAndResolveNonLeafTypesConcurrentlySupportPromises(): void
     {
         $jsSchema  = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $resolvers = [
@@ -1231,7 +1169,7 @@ class MockingTest extends TestCase
         GraphQLTools::addResolveFunctionsToSchema(
             $jsSchema,
             $resolvers,
-            ['requireResolversForResolveType' => false]
+            ['requireResolversForResolveType' => false],
         );
 
         $mockMap = [
@@ -1263,15 +1201,13 @@ class MockingTest extends TestCase
         ];
 
         GraphQL::promiseToExecute(new ReactPromiseAdapter(), $jsSchema, $testQuery)
-            ->then(static function ($res) use ($expected) : void {
+            ->then(static function ($res) use ($expected): void {
                 static::assertEquals($expected, $res->data);
             });
     }
 
-    /**
-     * @see it('let you mock with preserving resolvers, also when using logger')
-     */
-    public function testLetYoMockWithPreservingResolversAlsoWhenUsingLogger() : void
+    /** @see it('let you mock with preserving resolvers, also when using logger') */
+    public function testLetYoMockWithPreservingResolversAlsoWhenUsingLogger(): void
     {
         $resolvers = [
             'RootQuery' => [
@@ -1325,10 +1261,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('let you mock with preserving resolvers, also when using connectors')
-     */
-    public function testLetYoMockWithPreservingResolversAlsoWhenUsingConnectors() : void
+    /** @see it('let you mock with preserving resolvers, also when using connectors') */
+    public function testLetYoMockWithPreservingResolversAlsoWhenUsingConnectors(): void
     {
         $resolvers = [
             'RootQuery' => [
@@ -1348,7 +1282,7 @@ class MockingTest extends TestCase
                 'requireResolversForResolveType' => false,
             ],
             'connectors' => [
-                'testConnector' => static function () : array {
+                'testConnector' => static function (): array {
                     return [];
                 },
             ],
@@ -1386,10 +1320,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('let you mock with preserving resolvers, also when using both connectors and logger')
-     */
-    public function testLetYoMockWithPreservingResolversAlsoWhenUsingBothConnectorsAndLogger() : void
+    /** @see it('let you mock with preserving resolvers, also when using both connectors and logger') */
+    public function testLetYoMockWithPreservingResolversAlsoWhenUsingBothConnectorsAndLogger(): void
     {
         $resolvers = [
             'RootQuery' => [
@@ -1410,7 +1342,7 @@ class MockingTest extends TestCase
             ],
             'logger' => new SimpleLogger(),
             'connectors' => [
-                'testConnector' => static function () : array {
+                'testConnector' => static function (): array {
                     return [];
                 },
             ],
@@ -1448,10 +1380,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('let you resolve null with mocking and preserving resolvers')
-     */
-    public function testLetYouResolveNullWithMockingAndPreservingResolvers() : void
+    /** @see it('let you resolve null with mocking and preserving resolvers') */
+    public function testLetYouResolveNullWithMockingAndPreservingResolvers(): void
     {
         static::markTestSkipped('PHP cannot differentiate between undefined and null');
 
@@ -1467,7 +1397,7 @@ class MockingTest extends TestCase
         GraphQLTools::addResolveFunctionsToSchema(
             $jsSchema,
             $resolvers,
-            ['requireResolversForResolveType' => false]
+            ['requireResolversForResolveType' => false],
         );
 
         $mockMap = [
@@ -1502,10 +1432,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('lets you mock root query fields')
-     */
-    public function testLetsYouMockRootQueryFields() : void
+    /** @see it('lets you mock root query fields') */
+    public function testLetsYouMockRootQueryFields(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1530,10 +1458,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('lets you mock root mutation fields')
-     */
-    public function testLetsYouMockRootMutationFields() : void
+    /** @see it('lets you mock root mutation fields') */
+    public function testLetsYouMockRootMutationFields(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1558,10 +1484,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('lets you mock a list of a certain length')
-     */
-    public function testLetsYouMockAListOfCertainLength() : void
+    /** @see it('lets you mock a list of a certain length') */
+    public function testLetsYouMockAListOfCertainLength(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1589,10 +1513,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('lets you mock a list of a random length')
-     */
-    public function testLetsYouMockAListOfARandomLength() : void
+    /** @see it('lets you mock a list of a random length') */
+    public function testLetsYouMockAListOfARandomLength(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1619,10 +1541,8 @@ class MockingTest extends TestCase
         static::assertEquals(12, $res->data['returnListOfInt'][0]);
     }
 
-    /**
-     * @see it('lets you mock a list of specific variable length')
-     */
-    public function testLetsYouMockAListOfSpecificVariableLength() : void
+    /** @see it('lets you mock a list of specific variable length') */
+    public function testLetsYouMockAListOfSpecificVariableLength(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1650,10 +1570,8 @@ class MockingTest extends TestCase
         static::assertCount(5, $res->data['l5']);
     }
 
-    /**
-     * @see it('lets you provide a function for your MockList')
-     */
-    public function testLetsYouProvideAFunctionForYourMockList() : void
+    /** @see it('lets you provide a function for your MockList') */
+    public function testLetsYouProvideAFunctionForYourMockList(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
 
@@ -1684,10 +1602,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('lets you nest MockList in MockList')
-     */
-    public function testLetsYouNestMockListInMockList() : void
+    /** @see it('lets you nest MockList in MockList') */
+    public function testLetsYouNestMockListInMockList(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1716,10 +1632,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('lets you use arguments in nested MockList')
-     */
-    public function testLetsYouUseArgumentsInNestedMockList() : void
+    /** @see it('lets you use arguments in nested MockList') */
+    public function testLetsYouUseArgumentsInNestedMockList(): void
     {
         $jsSchema = GraphQLTools::buildSchemaFromTypeDefinitions($this->shorthand);
         $mockMap  = [
@@ -1749,10 +1663,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('works for a slightly more elaborate example')
-     */
-    public function testWorksForASlightlyMoreElaborateExample() : void
+    /** @see it('works for a slightly more elaborate example') */
+    public function testWorksForASlightlyMoreElaborateExample(): void
     {
         $short          = '
             type Thread {
@@ -1809,7 +1721,7 @@ class MockingTest extends TestCase
                                 return [
                                     'id' => $ai['num'],
                                 ];
-                            }
+                            },
                         );
                     },
                 ];
@@ -1853,10 +1765,8 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('works for resolvers returning javascript Dates')
-     */
-    public function testWorksForResovlersReturningDates() : void
+    /** @see it('works for resolvers returning javascript Dates') */
+    public function testWorksForResovlersReturningDates(): void
     {
         $typeDefs = '
     	    scalar Date
@@ -1934,17 +1844,13 @@ class MockingTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('allows instanceof checks in __resolveType')
-     */
-    public function testAllowsInstanceofChecksInResolveType() : void
+    /** @see it('allows instanceof checks in __resolveType') */
+    public function testAllowsInstanceofChecksInResolveType(): void
     {
         $account = new class
         {
-            /** @var string */
-            public $id;
-            /** @var string */
-            public $username;
+            public string $id;
+            public string $username;
 
             public function __construct()
             {

--- a/tests/ResolveInfoHelper.php
+++ b/tests/ResolveInfoHelper.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQLTools\Tests;
 
+use ArrayObject;
+use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -16,14 +18,14 @@ class ResolveInfoHelper
     public static function createResolveInfo(array $options): ResolveInfo
     {
         return new ResolveInfo(
-            FieldDefinition::create(['name' => $options['fieldName'] ?? '', 'type' => $options['returnType'] ?? Type::string()]),
-            $options['fieldNodes'] ?? [],
+            new FieldDefinition(['name' => $options['fieldName'] ?? '', 'type' => $options['returnType'] ?? Type::string()]),
+            $options['fieldNodes'] ?? new ArrayObject(),
             $options['parentType'] ?? new ObjectType(['name' => 'dummy']),
             $options['path'] ?? [],
             $options['schema'] ?? new Schema([]),
             $options['fragments'] ?? [],
             $options['rootValue'] ?? null,
-            $options['operation'] ?? null,
+            $options['operation'] ?? new OperationDefinitionNode([]),
             $options['variableValues'] ?? [],
         );
     }

--- a/tests/ResolveInfoHelper.php
+++ b/tests/ResolveInfoHelper.php
@@ -10,10 +10,8 @@ use GraphQL\Type\Schema;
 
 class ResolveInfoHelper
 {
-    /**
-     * @param mixed[] $options
-     */
-    public static function createResolveInfo(array $options) : ResolveInfo
+    /** @param mixed[] $options */
+    public static function createResolveInfo(array $options): ResolveInfo
     {
         return new ResolveInfo(
             $options['fieldName'] ?? '',
@@ -25,7 +23,7 @@ class ResolveInfoHelper
             $options['fragments'] ?? [],
             $options['rootValue'] ?? null,
             $options['operation'] ?? null,
-            $options['variableValues'] ?? []
+            $options['variableValues'] ?? [],
         );
     }
 }

--- a/tests/ResolveInfoHelper.php
+++ b/tests/ResolveInfoHelper.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace GraphQLTools\Tests;
 
+use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 
 class ResolveInfoHelper
@@ -14,9 +16,8 @@ class ResolveInfoHelper
     public static function createResolveInfo(array $options): ResolveInfo
     {
         return new ResolveInfo(
-            $options['fieldName'] ?? '',
-            $options['fieldNodes'] ?? null,
-            $options['returnType'] ?? null,
+            FieldDefinition::create(['name' => $options['fieldName'] ?? '', 'type' => $options['returnType'] ?? Type::string()]),
+            $options['fieldNodes'] ?? [],
             $options['parentType'] ?? new ObjectType(['name' => 'dummy']),
             $options['path'] ?? [],
             $options['schema'] ?? new Schema([]),

--- a/tests/SchemaGeneratorTest.php
+++ b/tests/SchemaGeneratorTest.php
@@ -1724,8 +1724,7 @@ class SchemaGeneratorTest extends TestCase
             }
         };
 
-        // different form original test. webonyx/graphql-php does not respect order in typeDefs
-        $assertFieldError('Query.bird', []);
+        $assertFieldError('Bird.id', []);
         $assertFieldError('Query.bird', [
             'Bird' => [
                 'id' => static function ($bird) {

--- a/tests/SchemaGeneratorTest.php
+++ b/tests/SchemaGeneratorTest.php
@@ -394,10 +394,10 @@ class SchemaGeneratorTest extends TestCase
             $combinedCandD['typeDefs'],
         ]);
 
-        static::assertContains('type TypeA', $result);
-        static::assertContains('type TypeB', $result);
-        static::assertContains('type TypeC', $result);
-        static::assertContains('type TypeD', $result);
+        static::assertStringContainsString('type TypeA', $result);
+        static::assertStringContainsString('type TypeB', $result);
+        static::assertStringContainsString('type TypeC', $result);
+        static::assertStringContainsString('type TypeD', $result);
     }
 
     /** @see it('properly deduplicates the array of type DefinitionNodes') */

--- a/tests/SchemaGeneratorTest.php
+++ b/tests/SchemaGeneratorTest.php
@@ -28,19 +28,19 @@ use SplObjectStorage;
 use stdClass;
 use Throwable;
 use TypeError;
-use const PHP_EOL;
+
 use function array_map;
 use function is_string;
 use function preg_match;
 use function strlen;
 use function strpos;
 
+use const PHP_EOL;
+
 class SchemaGeneratorTest extends TestCase
 {
-    /**
-     * @see it('throws an error if no schema is provided')
-     */
-    public function testThrowsAnErrorIfNoSchemaIsProvided() : void
+    /** @see it('throws an error if no schema is provided') */
+    public function testThrowsAnErrorIfNoSchemaIsProvided(): void
     {
         try {
             GraphQLTools::makeExecutableSchema([]);
@@ -50,10 +50,8 @@ class SchemaGeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @see it('throws an error if typeDefinitionNodes are not provided')
-     */
-    public function testThrowsAnErrorIfTypeDefinitionNodesAreNotProvided() : void
+    /** @see it('throws an error if typeDefinitionNodes are not provided') */
+    public function testThrowsAnErrorIfTypeDefinitionNodesAreNotProvided(): void
     {
         try {
             GraphQLTools::makeExecutableSchema([
@@ -66,10 +64,8 @@ class SchemaGeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @see it('throws an error if no resolveFunctions are provided')
-     */
-    public function testThrowsAnErrorIfNoResolveFunctionsAreProvided() : void
+    /** @see it('throws an error if no resolveFunctions are provided') */
+    public function testThrowsAnErrorIfNoResolveFunctionsAreProvided(): void
     {
         try {
             GraphQLTools::makeExecutableSchema([
@@ -82,10 +78,8 @@ class SchemaGeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @see it('throws an error if typeDefinitionNodes is neither string nor array nor schema AST')
-     */
-    public function testThrowsAnErrorIfTypeDefinitionNodesIsNeitherStringNorArrayNorSchemaAST() : void
+    /** @see it('throws an error if typeDefinitionNodes is neither string nor array nor schema AST') */
+    public function testThrowsAnErrorIfTypeDefinitionNodesIsNeitherStringNorArrayNorSchemaAST(): void
     {
         try {
             GraphQLTools::makeExecutableSchema([
@@ -95,15 +89,13 @@ class SchemaGeneratorTest extends TestCase
         } catch (Throwable $exception) {
             static::assertEquals(
                 'typeDefs must be a string, array or schema AST, got object',
-                $exception->getMessage()
+                $exception->getMessage(),
             );
         }
     }
 
-    /**
-     * @see it('throws an error if typeDefinitionNode array contains not only functions and strings')
-     */
-    public function testThrowsAnErrorIfTypeDefinitionNodeArrayContainsNotOnlyFunctionsAndStrings() : void
+    /** @see it('throws an error if typeDefinitionNode array contains not only functions and strings') */
+    public function testThrowsAnErrorIfTypeDefinitionNodeArrayContainsNotOnlyFunctionsAndStrings(): void
     {
         try {
             GraphQLTools::makeExecutableSchema([
@@ -114,15 +106,13 @@ class SchemaGeneratorTest extends TestCase
         } catch (Throwable $exception) {
             static::assertEquals(
                 'typeDef array must contain only strings and functions, got integer',
-                $exception->getMessage()
+                $exception->getMessage(),
             );
         }
     }
 
-    /**
-     * @see it('throws an error if resolverValidationOptions is not an object')
-     */
-    public function testThrowsAnErrorIfResolverValidationOptionsIsNotAnObject() : void
+    /** @see it('throws an error if resolverValidationOptions is not an object') */
+    public function testThrowsAnErrorIfResolverValidationOptionsIsNotAnObject(): void
     {
         try {
             GraphQLTools::makeExecutableSchema([
@@ -136,10 +126,8 @@ class SchemaGeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @see it('can generate a schema')
-     */
-    public function testCanGenerateASchema() : void
+    /** @see it('can generate a schema') */
+    public function testCanGenerateASchema(): void
     {
         $shorthand = '
             """
@@ -159,7 +147,7 @@ class SchemaGeneratorTest extends TestCase
 
         $resolve = [
             'RootQuery' => [
-                'species' => static function () : void {
+                'species' => static function (): void {
                     return;
                 },
             ],
@@ -266,10 +254,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($solution, $result->toArray());
     }
 
-    /**
-     * @see it('can generate a schema from an array of types')
-     */
-    public function testCanGenerateASchemaFromAnArrayOfTypes() : void
+    /** @see it('can generate a schema from an array of types') */
+    public function testCanGenerateASchemaFromAnArrayOfTypes(): void
     {
         $typeDefAry = [
             '
@@ -292,10 +278,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals('Query', $jsSchema->getQueryType()->name);
     }
 
-    /**
-     * @see it('can generate a schema from a parsed type definition')
-     */
-    public function testCanGenerateASchemaFromAParsedTypeDefinition() : void
+    /** @see it('can generate a schema from a parsed type definition') */
+    public function testCanGenerateASchemaFromAParsedTypeDefinition(): void
     {
         $typeDefSchema = Parser::parse('
             type Query {
@@ -314,10 +298,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals('Query', $jsSchema->getQueryType()->name);
     }
 
-    /**
-     * @see it('can generate a schema from an array of parsed and none parsed type definitions')
-     */
-    public function testCanGenerateASchemaFromAnArrayOfParsedAndNoneParsedTypeDefinitions() : void
+    /** @see it('can generate a schema from an array of parsed and none parsed type definitions') */
+    public function testCanGenerateASchemaFromAnArrayOfParsedAndNoneParsedTypeDefinitions(): void
     {
         $typeDefSchema = [
             Parser::parse('
@@ -343,7 +325,7 @@ class SchemaGeneratorTest extends TestCase
     /**
      * it('can generate a schema from an array of types with extensions')
      */
-    public function testCanGenerateASchemaFromAnArrayOfTypesWithExtensions() : void
+    public function testCanGenerateASchemaFromAnArrayOfTypesWithExtensions(): void
     {
         $typeDefAry = [
             '
@@ -370,10 +352,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertArrayHasKey('bar', $jsSchema->getQueryType()->getFields());
     }
 
-    /**
-     * @see it('can concatenateTypeDefs created by a function inside a closure')
-     */
-    public function testCanConcatenateTypeDefsCreatedByAFunctionInsideAClosure() : void
+    /** @see it('can concatenateTypeDefs created by a function inside a closure') */
+    public function testCanConcatenateTypeDefsCreatedByAFunctionInsideAClosure(): void
     {
         $typeA = [
             'typeDefs' => static function () {
@@ -420,10 +400,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertContains('type TypeD', $result);
     }
 
-    /**
-     * @see it('properly deduplicates the array of type DefinitionNodes')
-     */
-    public function testPropertyDeduplicatesTheArrayOfTheDefinitionNodes() : void
+    /** @see it('properly deduplicates the array of type DefinitionNodes') */
+    public function testPropertyDeduplicatesTheArrayOfTheDefinitionNodes(): void
     {
         $typeDefAry = [
             '
@@ -451,10 +429,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals('Query', $jsSchema->getQueryType()->name);
     }
 
-    /**
-     * @see it('works with imports, even circular ones')
-     */
-    public function testWorksWithImportsEventCircularOnes() : void
+    /** @see it('works with imports, even circular ones') */
+    public function testWorksWithImportsEventCircularOnes(): void
     {
         $typeDefAry = [
             '
@@ -494,10 +470,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals('Query', $jsSchema->getQueryType()->name);
     }
 
-    /**
-     * @see it('can generate a schema with resolve functions')
-     */
-    public function testCanGenerateASchemaWithResolveFunctions() : void
+    /** @see it('can generate a schema with resolve functions') */
+    public function testCanGenerateASchemaWithResolveFunctions(): void
     {
         $shorthand = '
             type BirdSpecies {
@@ -556,10 +530,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($solution, $result->toArray());
     }
 
-    /**
-     * @see it('can generate a schema with extensions that can use resolvers')
-     */
-    public function testCanGenerateASchemaWithExtensionsThatCanUseResolvers() : void
+    /** @see it('can generate a schema with extensions that can use resolvers') */
+    public function testCanGenerateASchemaWithExtensionsThatCanUseResolvers(): void
     {
         $shorthand = '
             type BirdSpecies {
@@ -634,10 +606,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($solution, $result->toArray());
     }
 
-    /**
-     * @see it('supports resolveType for unions')
-     */
-    public function testSupportsResolveTypeUnions() : void
+    /** @see it('supports resolveType for unions') */
+    public function testSupportsResolveTypeUnions(): void
     {
         $shorthand = '
             union Searchable = Person | Location
@@ -662,6 +632,7 @@ class SchemaGeneratorTest extends TestCase
                 'search' => [
                     'resolve' => static function ($root, $args) {
                         $name = $args['name'];
+
                         return [
                             [
                                 'name' => 'Tom ' . $name,
@@ -680,9 +651,11 @@ class SchemaGeneratorTest extends TestCase
                     if (isset($data['age'])) {
                         return $info->schema->getType('Person');
                     }
+
                     if (isset($data['coordinates'])) {
                         return $info->schema->getType('Location');
                     }
+
                     return null;
                 },
             ],
@@ -725,10 +698,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($solution, $result->toArray());
     }
 
-    /**
-     * @see it('can generate a schema with an array of resolvers')
-     */
-    public function testCanGenerateASchemaWithAnArrayOfResolvers() : void
+    /** @see it('can generate a schema with an array of resolvers') */
+    public function testCanGenerateASchemaWithAnArrayOfResolvers(): void
     {
         $shorthand = '
             type BirdSpecies {
@@ -813,10 +784,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($solution, $result->toArray());
     }
 
-    /**
-     * @see it('supports passing a GraphQLScalarType in resolveFunctions')
-     */
-    public function testSupportsPassingAScalarTypeInResolverFunctions() : void
+    /** @see it('supports passing a GraphQLScalarType in resolveFunctions') */
+    public function testSupportsPassingAScalarTypeInResolverFunctions(): void
     {
         $shorthand = '
             scalar JSON
@@ -845,10 +814,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertTrue(strlen($jsSchema->getType('JSON')->description) > 0);
     }
 
-    /**
-     * @see it('retains scalars after walking/recreating the schema')
-     */
-    public function testRetainsScalarsAfterWalkingRecreatingTheSchema() : void
+    /** @see it('retains scalars after walking/recreating the schema') */
+    public function testRetainsScalarsAfterWalkingRecreatingTheSchema(): void
     {
         $shorthand = '
             scalar Test
@@ -882,6 +849,7 @@ class SchemaGeneratorTest extends TestCase
                         case $ast instanceof StringValueNode:
                         case $ast instanceof IntValueNode:
                             return 'scalar:' . $ast->value;
+
                         default:
                             return null;
                     }
@@ -891,6 +859,7 @@ class SchemaGeneratorTest extends TestCase
                 'testIn' => static function ($_, $args) {
                     $input = $args['input'];
                     static::assertStringStartsWith('scalar:', $input);
+
                     return $input;
                 },
                 'test' => static function () {
@@ -920,10 +889,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals(['test' => 'scalar:42', 'testIn' => 'scalar:1'], $result->toArray()['data']);
     }
 
-    /**
-     * @see it('should support custom scalar usage on client-side query execution')
-     */
-    public function testShouldSupportCustomScalarUsageOnClientSideQueryExecution() : void
+    /** @see it('should support custom scalar usage on client-side query execution') */
+    public function testShouldSupportCustomScalarUsageOnClientSideQueryExecution(): void
     {
         $shorthand = '
             scalar CustomScalar
@@ -977,10 +944,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertArrayNotHasKey('errors', $result->toArray());
     }
 
-    /**
-     * @see it('should work with an Odd custom scalar type')
-     */
-    public function testShouldWorkWithAnOddCustomScalarType() : void
+    /** @see it('should work with an Odd custom scalar type') */
+    public function testShouldWorkWithAnOddCustomScalarType(): void
     {
         $oddValue = static function ($value) {
             return $value % 2 === 1 ? $value : null;
@@ -995,6 +960,7 @@ class SchemaGeneratorTest extends TestCase
                 if ($ast instanceof IntValueNode) {
                     return $oddValue($ast->value);
                 }
+
                 return null;
             },
         ]);
@@ -1048,10 +1014,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertArrayNotHasKey('errors', $result->toArray());
     }
 
-    /**
-     * @see it('should work with a Date custom scalar type')
-     */
-    public function testShouldWorkWithADateCustomScalarType() : void
+    /** @see it('should work with a Date custom scalar type') */
+    public function testShouldWorkWithADateCustomScalarType(): void
     {
         $DateType = new CustomScalarType([
             'name' => 'Date',
@@ -1066,6 +1030,7 @@ class SchemaGeneratorTest extends TestCase
                 if ($ast instanceof IntValueNode) {
                     return $ast->value;
                 }
+
                 return null;
             },
         ]);
@@ -1119,10 +1084,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertArrayNotHasKey('errors', $result->toArray());
     }
 
-    /**
-     * @see it('supports passing a GraphQLEnumType in resolveFunctions')
-     */
-    public function testSupportsPassingAGraphQLEnumTypeInResolveFunctions() : void
+    /** @see it('supports passing a GraphQLEnumType in resolveFunctions') */
+    public function testSupportsPassingAGraphQLEnumTypeInResolveFunctions(): void
     {
         $shorthand = '
             enum Color {
@@ -1155,10 +1118,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertInstanceOf(EnumType::class, $jsSchema->getType('NumericEnum'));
     }
 
-    /**
-     * @see it('supports passing the value for a GraphQLEnumType in resolveFunctions')
-     */
-    public function testSupportsPassingTheValueFoAGraphQLEnumTypeInResolveFunctions() : void
+    /** @see it('supports passing the value for a GraphQLEnumType in resolveFunctions') */
+    public function testSupportsPassingTheValueFoAGraphQLEnumTypeInResolveFunctions(): void
     {
         $shorthand = '
             enum Color {
@@ -1216,10 +1177,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertArrayNotHasKey('errors', $result->toArray());
     }
 
-    /**
-     * @see it('supports resolving the value for a GraphQLEnumType in input types')
-     */
-    public function testSupportsResolvingTheValueForAGraphQLEnumTypeInInputTypes() : void
+    /** @see it('supports resolving the value for a GraphQLEnumType in input types') */
+    public function testSupportsResolvingTheValueForAGraphQLEnumTypeInInputTypes(): void
     {
         $shorthand = '
             enum Color {
@@ -1273,10 +1232,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertArrayNotHasKey('errors', $result->toArray());
     }
 
-    /**
-     * @see it('can set description and deprecation reason')
-     */
-    public function testCanSetDescriptionAndDeprecationReason() : void
+    /** @see it('can set description and deprecation reason') */
+    public function testCanSetDescriptionAndDeprecationReason(): void
     {
         $shorthand = '
             type BirdSpecies {
@@ -1348,7 +1305,7 @@ class SchemaGeneratorTest extends TestCase
     /**
      * * @see it('shows a warning if a field has arguments but no resolve func')
      */
-    public function testShowsAWarningIfAFieldHasArgumentsButNoResolveFunc() : void
+    public function testShowsAWarningIfAFieldHasArgumentsButNoResolveFunc(): void
     {
         $short = '
             type Query {
@@ -1373,10 +1330,8 @@ class SchemaGeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @see it('does not throw an error if `resolverValidationOptions.requireResolversForArgs` is false')
-     */
-    public function testDoesNotThrowAnErrorIfResolverValidationOptionsRequireResolversForArgsIsFalse() : void
+    /** @see it('does not throw an error if `resolverValidationOptions.requireResolversForArgs` is false') */
+    public function testDoesNotThrowAnErrorIfResolverValidationOptionsRequireResolversForArgsIsFalse(): void
     {
         $short = '
             type Query{
@@ -1397,10 +1352,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertTrue(true);
     }
 
-    /**
-     * @see it('throws an error if a resolver is not a function')
-     */
-    public function testThrowsAnErrorIfAResolverIsNotAFunction() : void
+    /** @see it('throws an error if a resolver is not a function') */
+    public function testThrowsAnErrorIfAResolverIsNotAFunction(): void
     {
         $short = '
             type Query{
@@ -1423,10 +1376,8 @@ class SchemaGeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @see it('shows a warning if a field is not scalar, but has no resolve func')
-     */
-    public function testShowsAWarningIfAFieldIsNotScalarButHasNoResolveFunc() : void
+    /** @see it('shows a warning if a field is not scalar, but has no resolve func') */
+    public function testShowsAWarningIfAFieldIsNotScalarButHasNoResolveFunc(): void
     {
         $short = '
             type Bird {
@@ -1460,7 +1411,7 @@ class SchemaGeneratorTest extends TestCase
      * @see it('allows non-scalar field to use default resolve func if
      * `resolverValidationOptions.requireResolversForNonScalar` = false')
      */
-    public function testAllowsNonScalarFieldToUseDefaultResolveFuncIfResolverValidationIsOff() : void
+    public function testAllowsNonScalarFieldToUseDefaultResolveFuncIfResolverValidationIsOff(): void
     {
         $short = '
             type Bird {
@@ -1485,10 +1436,8 @@ class SchemaGeneratorTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * @see it('throws if resolver defined for non-object/interface type')
-     */
-    public function testThrowsIfResolverDefinedForNonObjectInterfaceType() : void
+    /** @see it('throws if resolver defined for non-object/interface type') */
+    public function testThrowsIfResolverDefinedForNonObjectInterfaceType(): void
     {
         $short = '
             union Searchable = Person | Location
@@ -1526,7 +1475,7 @@ class SchemaGeneratorTest extends TestCase
         } catch (Throwable $exception) {
             static::assertEquals(
                 'Searchable was defined in resolvers, but it\'s not an object',
-                $exception->getMessage()
+                $exception->getMessage(),
             );
         }
 
@@ -1540,10 +1489,8 @@ class SchemaGeneratorTest extends TestCase
         ]);
     }
 
-    /**
-     * @see it('throws if resolver defined for non existent type')
-     */
-    public function testThrowsIfResolverDefinedForNonExistentType() : void
+    /** @see it('throws if resolver defined for non existent type') */
+    public function testThrowsIfResolverDefinedForNonExistentType(): void
     {
         $short = '
             type Person {
@@ -1583,10 +1530,8 @@ class SchemaGeneratorTest extends TestCase
         ]);
     }
 
-    /**
-     * @see it('throws if resolver value is invalid')
-     */
-    public function testThrowsIfResolverValueIsInvalid() : void
+    /** @see it('throws if resolver value is invalid') */
+    public function testThrowsIfResolverValueIsInvalid(): void
     {
         $short = '
             type Person {
@@ -1613,15 +1558,13 @@ class SchemaGeneratorTest extends TestCase
             static::assertEquals(
                 '"Searchable" defined in resolvers, but has invalid value "NULL".' .
                 ' A resolver\'s value must be of type object or function.',
-                $exception->getMessage()
+                $exception->getMessage(),
             );
         }
     }
 
-    /**
-     * @see it('doesnt let you define resolver field not present in schema')
-     */
-    public function testDoesntLetYouDefineResolverFieldNotPresentInSchema() : void
+    /** @see it('doesnt let you define resolver field not present in schema') */
+    public function testDoesntLetYouDefineResolverFieldNotPresentInSchema(): void
     {
         $short = '
             type Person {
@@ -1661,10 +1604,8 @@ class SchemaGeneratorTest extends TestCase
         ]);
     }
 
-    /**
-     * @see it('does not let you define resolver field for enum values not present in schema')
-     */
-    public function testDoesNotLetYouDefineResolverFieldForEnumValuesNotPresentInSchema() : void
+    /** @see it('does not let you define resolver field for enum values not present in schema') */
+    public function testDoesNotLetYouDefineResolverFieldForEnumValuesNotPresentInSchema(): void
     {
         $short = '
             enum Color {
@@ -1698,7 +1639,7 @@ class SchemaGeneratorTest extends TestCase
         } catch (Throwable $exception) {
             static::assertEquals(
                 'Color.NO_RESOLVER was defined in resolvers, but enum is not in schema',
-                $exception->getMessage()
+                $exception->getMessage(),
             );
         }
 
@@ -1709,10 +1650,8 @@ class SchemaGeneratorTest extends TestCase
         ]);
     }
 
-    /**
-     * @see it('throws if conflicting validation options are passed')
-     */
-    public function testThrowsIfConflictingValidationOptionsArePassed() : void
+    /** @see it('throws if conflicting validation options are passed') */
+    public function testThrowsIfConflictingValidationOptionsArePassed(): void
     {
         $typeDefs  = '
             type Bird {
@@ -1727,7 +1666,7 @@ class SchemaGeneratorTest extends TestCase
         ';
         $resolvers = [];
 
-        $assertOptionsError = static function ($resolverValidationOptions) use ($typeDefs, $resolvers) : void {
+        $assertOptionsError = static function ($resolverValidationOptions) use ($typeDefs, $resolvers): void {
             try {
                 GraphQLTools::makeExecutableSchema([
                     'typeDefs' => $typeDefs,
@@ -1757,10 +1696,8 @@ class SchemaGeneratorTest extends TestCase
         ]);
     }
 
-    /**
-     * @see it('throws for any missing field if `resolverValidationOptions.requireResolversForAllFields` = true')
-     */
-    public function testThrowsForAnyMissingFieldIfResolverValidationOptionsRequireResolversForAllFieldsTrue() : void
+    /** @see it('throws for any missing field if `resolverValidationOptions.requireResolversForAllFields` = true') */
+    public function testThrowsForAnyMissingFieldIfResolverValidationOptionsRequireResolversForAllFieldsTrue(): void
     {
         $typeDefs = '
             type Bird {
@@ -1774,7 +1711,7 @@ class SchemaGeneratorTest extends TestCase
             }
         ';
 
-        $assertFieldError = static function ($errorMatcher, $resolvers) use ($typeDefs) : void {
+        $assertFieldError = static function ($errorMatcher, $resolvers) use ($typeDefs): void {
             try {
                 GraphQLTools::makeExecutableSchema([
                     'typeDefs' => $typeDefs,
@@ -1809,7 +1746,7 @@ class SchemaGeneratorTest extends TestCase
      * @see it('does not throw if all fields are satisfied
      * when `resolverValidationOptions.requireResolversForAllFields` = true')
      */
-    public function testDoesNotThrowIfAllFieldsAreSatisfied() : void
+    public function testDoesNotThrowIfAllFieldsAreSatisfied(): void
     {
         $typeDefs = '
             type Bird {
@@ -1845,10 +1782,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertTrue(true);
     }
 
-    /**
-     * @see it('throws an error if a resolve field cannot be used')
-     */
-    public function testThrowsAnErrorIfAResolveFieldCannotBeUsed() : void
+    /** @see it('throws an error if a resolve field cannot be used') */
+    public function testThrowsAnErrorIfAResolveFieldCannotBeUsed(): void
     {
         $shorthand = '
             type BirdSpecies {
@@ -1867,6 +1802,7 @@ class SchemaGeneratorTest extends TestCase
             'RootQuery' => [
                 'speciez' => static function ($root, $args) {
                     $name = $args['name'];
+
                     return [
                         [
                             'name' => 'Hello ' . $name . '!',
@@ -1888,10 +1824,8 @@ class SchemaGeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @see it('throws an error if a resolve type is not in schema')
-     */
-    public function testThrowsAnErrorIfAResolveTypeIsNotInSchema() : void
+    /** @see it('throws an error if a resolve type is not in schema') */
+    public function testThrowsAnErrorIfAResolveTypeIsNotInSchema(): void
     {
         $shorthand = '
             type BirdSpecies {
@@ -1932,10 +1866,8 @@ class SchemaGeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @see it('logs an error if a resolve function fails')
-     */
-    public function testLogsAnErrorIfAResolveFunctionFails() : void
+    /** @see it('logs an error if a resolve function fails') */
+    public function testLogsAnErrorIfAResolveFunctionFails(): void
     {
         $shorthand = '
             type RootQuery {
@@ -1948,7 +1880,7 @@ class SchemaGeneratorTest extends TestCase
 
         $resolve = [
             'RootQuery' => [
-                'species' => static function () : void {
+                'species' => static function (): void {
                     throw new Exception('oops!');
                 },
             ],
@@ -1968,10 +1900,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($expected, $logger->errors[0]->getMessage());
     }
 
-    /**
-     * @see it('will throw errors on undefined if you tell it to')
-     */
-    public function testWillThrowErrorsOnUndefinedIfYouTellItTo() : void
+    /** @see it('will throw errors on undefined if you tell it to') */
+    public function testWillThrowErrorsOnUndefinedIfYouTellItTo(): void
     {
         static::markTestSkipped('There is no undefined in PHP');
 
@@ -1987,7 +1917,7 @@ class SchemaGeneratorTest extends TestCase
 
         $resolve = [
             'RootQuery' => [
-                'species' => static function () : void {
+                'species' => static function (): void {
                 },
                 'stuff' => static function () {
                     return 'stuff';
@@ -2017,7 +1947,7 @@ class SchemaGeneratorTest extends TestCase
      * @see describe('Schema level resolve function')
      * @see it('actually runs')
      */
-    public function testActuallyRuns() : void
+    public function testActuallyRuns(): void
     {
         $jsSchema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
@@ -2038,10 +1968,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals('ROOTstrix', $res->data['species']);
     }
 
-    /**
-     * @see it('can wrap fields that do not have a resolver defined')
-     */
-    public function testCanWrapFieldsThatDoNotHaveAResolverDefined() : void
+    /** @see it('can wrap fields that do not have a resolver defined') */
+    public function testCanWrapFieldsThatDoNotHaveAResolverDefined(): void
     {
         $jsSchema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
@@ -2061,10 +1989,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals('stuff', $res->data['stuff']);
     }
 
-    /**
-     * @see it('runs only once per query')
-     */
-    public function testRunsOnlyOncePerQuery() : void
+    /** @see it('runs only once per query') */
+    public function testRunsOnlyOncePerQuery(): void
     {
         $simpleResolvers = [
             'RootQuery' => [
@@ -2079,6 +2005,7 @@ class SchemaGeneratorTest extends TestCase
                 },
                 'species' => static function ($root, $args) {
                     $name = $args['name'];
+
                     return $root['species'] . $name;
                 },
             ],
@@ -2093,10 +2020,13 @@ class SchemaGeneratorTest extends TestCase
         $rootResolver = static function () use (&$count) {
             if ($count === 0) {
                 $count += 1;
+
                 return ['stuff' => 'stuff', 'species' => 'some '];
             }
+
             if ($count === 1) {
                 $count += 1;
+
                 return ['stuff' => 'stuff2', 'species' => 'species2 '];
             }
 
@@ -2124,17 +2054,15 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($expected2, $res2->data);
     }
 
-    /**
-     * @see it('can attach things to context')
-     */
-    public function testCanAttachThingsToContext() : void
+    /** @see it('can attach things to context') */
+    public function testCanAttachThingsToContext(): void
     {
         $jsSchema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
             'resolvers' => TestHelper::getTestResolvers(),
         ]);
 
-        $rootResolver = static function ($o, $a, &$ctx) : void {
+        $rootResolver = static function ($o, $a, &$ctx): void {
             $ctx->usecontext = 'ABC';
         };
 
@@ -2148,10 +2076,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('can attach with existing static connectors')
-     */
-    public function testCanAttachWithExistingStaticConnectors() : void
+    /** @see it('can attach with existing static connectors') */
+    public function testCanAttachWithExistingStaticConnectors(): void
     {
         $resolvers = [
             'RootQuery' => [
@@ -2189,10 +2115,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('actually attaches the connectors')
-     */
-    public static function testActuallyAttachesTheConnectors() : void
+    /** @see it('actually attaches the connectors') */
+    public static function testActuallyAttachesTheConnectors(): void
     {
         $jsSchema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
@@ -2210,10 +2134,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('actually passes the context to the connector constructor')
-     */
-    public function testActuallyPassesTheContextToTheConnectorConstructor() : void
+    /** @see it('actually passes the context to the connector constructor') */
+    public function testActuallyPassesTheContextToTheConnectorConstructor(): void
     {
         $jsSchema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
@@ -2231,10 +2153,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('throws error if trying to attach connectors twice')
-     */
-    public function testThrowsErrorIfTryingToAttachConnectorsTwice() : void
+    /** @see it('throws error if trying to attach connectors twice') */
+    public function testThrowsErrorIfTryingToAttachConnectorsTwice(): void
     {
         $jsSchema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
@@ -2250,10 +2170,8 @@ class SchemaGeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @see it('throws error during execution if context is not an object')
-     */
-    public function testThrowsErrorDuringExecutionIfContextIsNotAnObject() : void
+    /** @see it('throws error during execution if context is not an object') */
+    public function testThrowsErrorDuringExecutionIfContextIsNotAnObject(): void
     {
         $jsSchema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
@@ -2267,10 +2185,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals('Cannot attach connector because context is not an object: string', $res->errors[0]->getMessage());
     }
 
-    /**
-     * @see it('throws error if trying to attach non-functional connectors')
-     */
-    public function testThrowsErrorIfTryingToAttachNonFunctionalConnectors() : void
+    /** @see it('throws error if trying to attach non-functional connectors') */
+    public function testThrowsErrorIfTryingToAttachNonFunctionalConnectors(): void
     {
         $jsSchema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
@@ -2287,10 +2203,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals('Connector must be a function or an class', $res->errors[0]->getMessage());
     }
 
-    /**
-     * @see it('does not interfere with schema level resolve function')
-     */
-    public function testDoesNotInterfereWithSchemaLevelResolveFunction() : void
+    /** @see it('does not interfere with schema level resolve function') */
+    public function testDoesNotInterfereWithSchemaLevelResolveFunction(): void
     {
         $jsSchema     = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
@@ -2324,7 +2238,7 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    public function testThrowsErrorIfConnectorsArgumentIsAnNumericArray() : void
+    public function testThrowsErrorIfConnectorsArgumentIsAnNumericArray(): void
     {
         $jsSchema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
@@ -2339,10 +2253,8 @@ class SchemaGeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @see it('outputs a working GraphQL schema')
-     */
-    public function testOutputsAWorkingGraphQLSchema() : void
+    /** @see it('outputs a working GraphQL schema') */
+    public function testOutputsAWorkingGraphQLSchema(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => TestHelper::getTestSchema(),
@@ -2368,10 +2280,8 @@ class SchemaGeneratorTest extends TestCase
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('can chain two resolvers')
-     */
-    public function testCanChainTwoResolvers() : void
+    /** @see it('can chain two resolvers') */
+    public function testCanChainTwoResolvers(): void
     {
         $r1 = static function ($root) {
             return $root + 1;
@@ -2385,10 +2295,8 @@ class SchemaGeneratorTest extends TestCase
         self::assertEquals(3, $rChained(0, ['addend' => 2], null, null));
     }
 
-    /**
-     * @see it('uses default resolver when a resolver is undefined')
-     */
-    public function testUsesDefaultResolverWhenAResolverIsUndefined() : void
+    /** @see it('uses default resolver when a resolver is undefined') */
+    public function testUsesDefaultResolverWhenAResolverIsUndefined(): void
     {
         $r1 = static function ($root, $args) {
             return [
@@ -2406,7 +2314,7 @@ class SchemaGeneratorTest extends TestCase
 
         static::assertEquals(
             'tony',
-            $rChained(0, ['name' => 'tony'], null, ResolveInfoHelper::createResolveInfo(['fieldName' => 'person']))
+            $rChained(0, ['name' => 'tony'], null, ResolveInfoHelper::createResolveInfo(['fieldName' => 'person'])),
         );
     }
 }

--- a/tests/SchemaGeneratorTest/AttachDirectiveResolversOnFieldTest.php
+++ b/tests/SchemaGeneratorTest/AttachDirectiveResolversOnFieldTest.php
@@ -12,6 +12,8 @@ use GraphQLTools\Generate\AttachDirectiveResolvers;
 use GraphQLTools\GraphQLTools;
 use PHPUnit\Framework\TestCase;
 use Throwable;
+
+use function assert;
 use function is_string;
 use function React\Promise\resolve;
 use function strtolower;
@@ -19,18 +21,15 @@ use function strtoupper;
 
 class AttachDirectiveResolversOnFieldTest extends TestCase
 {
-    /** @var ReactPromiseAdapter */
-    protected $promiseAdapter;
-    /** @var string */
-    protected $testSchemaWithDirectives;
-    /** @var object */
-    protected $testObject;
+    protected ReactPromiseAdapter $promiseAdapter;
+    protected string $testSchemaWithDirectives;
+    protected object $testObject;
     /** @var mixed[] */
-    protected $testResolversDirectives;
+    protected array $testResolversDirectives;
     /** @var mixed[] */
-    protected $directiveResolvers;
+    protected array $directiveResolvers;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -75,7 +74,7 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
                 'multiDirectives' => static function () {
                     return 'Giau. Tran Minh';
                 },
-                'throwError' => static function () : void {
+                'throwError' => static function (): void {
                     throw new Error('This error for testing');
                 },
             ],
@@ -122,10 +121,8 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
         ];
     }
 
-    /**
-     * @see it('throws error if directiveResolvers argument is an array')
-     */
-    public function testThrowsErrorIfDirectiveResolversArgumentIsAnArray() : void
+    /** @see it('throws error if directiveResolvers argument is an array') */
+    public function testThrowsErrorIfDirectiveResolversArgumentIsAnArray(): void
     {
         static::markTestSkipped('Not failable in php');
 
@@ -142,10 +139,8 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
         }
     }
 
-    /**
-     * @see it('upper String from resolvers')
-     */
-    public function testUpperStringFromResolvers() : void
+    /** @see it('upper String from resolvers') */
+    public function testUpperStringFromResolvers(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->testSchemaWithDirectives,
@@ -159,20 +154,18 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
 
         $expected = ['hello' => 'GIAU. TRAN MINH'];
 
-        /** @var ExecutionResult $res */
         $res = null;
+        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
-            ->then(static function (ExecutionResult $r) use (&$res) : void {
+            ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
             });
 
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('using default resolver for object property')
-     */
-    public function testUsingDefaultResolverForObjectProperty() : void
+    /** @see it('using default resolver for object property') */
+    public function testUsingDefaultResolverForObjectProperty(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->testSchemaWithDirectives,
@@ -190,20 +183,18 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
             'object' => ['hello' => 'GIAU. TRAN MINH'],
         ];
 
-        /** @var ExecutionResult $res */
         $res = null;
+        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
-            ->then(static function (ExecutionResult $r) use (&$res) : void {
+            ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
             });
 
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('passes in directive arguments to the directive resolver')
-     */
-    public function testPassesInDirectiveArgumentsToTheDirectiveResolver() : void
+    /** @see it('passes in directive arguments to the directive resolver') */
+    public function testPassesInDirectiveArgumentsToTheDirectiveResolver(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->testSchemaWithDirectives,
@@ -217,20 +208,18 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
 
         $expected = ['withDefault' => 'some default_value'];
 
-        /** @var ExecutionResult $res */
         $res = null;
+        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
-            ->then(static function (ExecutionResult $r) use (&$res) : void {
+            ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
             });
 
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('No effect if missing directive resolvers')
-     */
-    public function testNoEffectIfMissingDirectiveResolvers() : void
+    /** @see it('No effect if missing directive resolvers') */
+    public function testNoEffectIfMissingDirectiveResolvers(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->testSchemaWithDirectives,
@@ -245,19 +234,17 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
 
         $expected = ['hello' => 'giau. tran minh'];
 
-        /** @var ExecutionResult $res */
         $res = null;
+        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
-            ->then(static function (ExecutionResult $r) use (&$res) : void {
+            ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
             });
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('If resolver return Promise, keep using it')
-     */
-    public function testIfResolverReturnPromiseKeepUsingIt() : void
+    /** @see it('If resolver return Promise, keep using it') */
+    public function testIfResolverReturnPromiseKeepUsingIt(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->testSchemaWithDirectives,
@@ -271,19 +258,17 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
 
         $expected = ['asyncResolver' => 'GIAU. TRAN MINH'];
 
-        /** @var ExecutionResult $res */
         $res = null;
+        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
-            ->then(static function (ExecutionResult $r) use (&$res) : void {
+            ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
             });
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('Multi directives apply with LTR order')
-     */
-    public function testMultiDirectivesApplyWithLTROrder() : void
+    /** @see it('Multi directives apply with LTR order') */
+    public function testMultiDirectivesApplyWithLTROrder(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->testSchemaWithDirectives,
@@ -297,19 +282,17 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
 
         $expected = ['multiDirectives' => 'giau. tran minh'];
 
-        /** @var ExecutionResult $res */
         $res = null;
+        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
-            ->then(static function (ExecutionResult $r) use (&$res) : void {
+            ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
             });
         static::assertEquals($expected, $res->data);
     }
 
-    /**
-     * @see it('Allow to catch error from next resolver')
-     */
-    public function testAllowToCatchErrorFromNextResolver() : void
+    /** @see it('Allow to catch error from next resolver') */
+    public function testAllowToCatchErrorFromNextResolver(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => $this->testSchemaWithDirectives,
@@ -323,10 +306,10 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
 
         $expected = ['throwError' => 'This error for testing'];
 
-        /** @var ExecutionResult $res */
         $res = null;
+        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
-            ->then(static function (ExecutionResult $r) use (&$res) : void {
+            ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
             });
 

--- a/tests/SchemaGeneratorTest/AttachDirectiveResolversOnFieldTest.php
+++ b/tests/SchemaGeneratorTest/AttachDirectiveResolversOnFieldTest.php
@@ -13,7 +13,6 @@ use GraphQLTools\GraphQLTools;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
-use function assert;
 use function is_string;
 use function React\Promise\resolve;
 use function strtolower;
@@ -155,7 +154,6 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
         $expected = ['hello' => 'GIAU. TRAN MINH'];
 
         $res = null;
-        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
             ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
@@ -184,7 +182,6 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
         ];
 
         $res = null;
-        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
             ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
@@ -209,7 +206,6 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
         $expected = ['withDefault' => 'some default_value'];
 
         $res = null;
-        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
             ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
@@ -235,7 +231,6 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
         $expected = ['hello' => 'giau. tran minh'];
 
         $res = null;
-        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
             ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
@@ -259,7 +254,6 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
         $expected = ['asyncResolver' => 'GIAU. TRAN MINH'];
 
         $res = null;
-        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
             ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
@@ -283,7 +277,6 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
         $expected = ['multiDirectives' => 'giau. tran minh'];
 
         $res = null;
-        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
             ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;
@@ -307,7 +300,6 @@ class AttachDirectiveResolversOnFieldTest extends TestCase
         $expected = ['throwError' => 'This error for testing'];
 
         $res = null;
-        assert($res instanceof ExecutionResult);
         GraphQL::promiseToExecute($this->promiseAdapter, $schema, $query, [], [])
             ->then(static function (ExecutionResult $r) use (&$res): void {
                 $res = $r;

--- a/tests/SchemaGeneratorTest/CanSpecifyLexicalParserOptionsTest.php
+++ b/tests/SchemaGeneratorTest/CanSpecifyLexicalParserOptionsTest.php
@@ -9,10 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 class CanSpecifyLexicalParserOptionsTest extends TestCase
 {
-    /**
-     * @see it("can specify 'noLocation' option")
-     */
-    public function testCanSpecifyNoLocationOption() : void
+    /** @see it("can specify 'noLocation' option") */
+    public function testCanSpecifyNoLocationOption(): void
     {
         $schema = GraphQLTools::makeExecutableSchema([
             'typeDefs' => '
@@ -30,10 +28,8 @@ class CanSpecifyLexicalParserOptionsTest extends TestCase
         static::assertNull($schema->getAstNode()->loc);
     }
 
-    /**
-     * @see it("can specify 'experimentalFragmentVariables' option")
-     */
-    public function testCanSpecifyExperimentalFragmentVariablesOption() : void
+    /** @see it("can specify 'experimentalFragmentVariables' option") */
+    public function testCanSpecifyExperimentalFragmentVariablesOption(): void
     {
         $typeDefs = '
             type Hello {

--- a/tests/SchemaGeneratorTest/CanSpecifyLexicalParserOptionsTest.php
+++ b/tests/SchemaGeneratorTest/CanSpecifyLexicalParserOptionsTest.php
@@ -25,12 +25,14 @@ class CanSpecifyLexicalParserOptionsTest extends TestCase
             'parseOptions' => ['noLocation' => true],
         ]);
 
-        static::assertNull($schema->getAstNode()->loc);
+        static::assertNull($schema->astNode->loc);
     }
 
     /** @see it("can specify 'experimentalFragmentVariables' option") */
     public function testCanSpecifyExperimentalFragmentVariablesOption(): void
     {
+        $this->markTestSkipped('Currently broken in webonyx/graphql-php');
+
         $typeDefs = '
             type Hello {
                 world(phrase: String): String

--- a/tests/SchemaGeneratorTest/CanSpecifyLexicalParserOptionsTest.php
+++ b/tests/SchemaGeneratorTest/CanSpecifyLexicalParserOptionsTest.php
@@ -31,7 +31,10 @@ class CanSpecifyLexicalParserOptionsTest extends TestCase
     /** @see it("can specify 'experimentalFragmentVariables' option") */
     public function testCanSpecifyExperimentalFragmentVariablesOption(): void
     {
-        $this->markTestSkipped('Currently broken in webonyx/graphql-php');
+        $this->markTestSkipped('Currently not fully supported.');
+
+        // Typedef does not make sense. Cf. https://github.com/webonyx/graphql-php/issues/1707
+        // Even with a proper query, the experimental fragment variables parsing fail.
 
         $typeDefs = '
             type Hello {

--- a/tests/SchemaGeneratorTest/InterfaceResolverInheritanceTest.php
+++ b/tests/SchemaGeneratorTest/InterfaceResolverInheritanceTest.php
@@ -10,10 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 class InterfaceResolverInheritanceTest extends TestCase
 {
-    /**
-     * @see it('copies resolvers from the interfaces')
-     */
-    public function testCopiesResolversFromTheInterfaces() : void
+    /** @see it('copies resolvers from the interfaces') */
+    public function testCopiesResolversFromTheInterfaces(): void
     {
         $testSchemaWithInterfaceResolvers = '
             interface Node {
@@ -81,10 +79,8 @@ class InterfaceResolverInheritanceTest extends TestCase
         ], $response->toArray());
     }
 
-    /**
-     * @see it('respects interface order and existing resolvers')
-     */
-    public function testRespectsInterfaceOrderAndExistingResolvers() : void
+    /** @see it('respects interface order and existing resolvers') */
+    public function testRespectsInterfaceOrderAndExistingResolvers(): void
     {
         $testSchemaWithInterfaceResolvers = '
             interface Node {

--- a/tests/SchemaGeneratorTest/InterfacesTest.php
+++ b/tests/SchemaGeneratorTest/InterfacesTest.php
@@ -11,18 +11,17 @@ use Throwable;
 
 class InterfacesTest extends TestCase
 {
-    /** @var string */
-    protected $testSchemaWithInterfaces;
+    protected string $testSchemaWithInterfaces;
     /** @var mixed[] */
-    protected $user;
+    protected array $user;
     /** @var mixed[] */
-    protected $queryResolver;
-    /** @var string */
-    protected $query;
+    protected array $queryResolver;
+    protected string $query;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
+
         $this->testSchemaWithInterfaces = '
             interface Node {
                 id: ID!
@@ -63,10 +62,8 @@ class InterfacesTest extends TestCase
         ';
     }
 
-    /**
-     * @see it('throws if there is no interface resolveType resolver')
-     */
-    public function testThrowsIfThereIsNoInterfaceResolveTypeResolver() : void
+    /** @see it('throws if there is no interface resolveType resolver') */
+    public function testThrowsIfThereIsNoInterfaceResolveTypeResolver(): void
     {
         $resolvers = [
             'Query' => $this->queryResolver,
@@ -84,10 +81,8 @@ class InterfacesTest extends TestCase
         }
     }
 
-    /**
-     * @see it('does not throw if there is an interface resolveType resolver')
-     */
-    public function testDoesNotThrowIfThereIsAnInterfaceResolveTypeResolver() : void
+    /** @see it('does not throw if there is an interface resolveType resolver') */
+    public function testDoesNotThrowIfThereIsAnInterfaceResolveTypeResolver(): void
     {
         $resolvers = [
             'Query' => $this->queryResolver,
@@ -108,10 +103,8 @@ class InterfacesTest extends TestCase
         static::assertEmpty($response->errors);
     }
 
-    /**
-     * @see it('does not warn if requireResolversForResolveType is disabled and there are missing resolvers')
-     */
-    public function testDoesNotWarnIfRequireResolversForResolveTypeIsDisabledAndThereAreMissingResolvers() : void
+    /** @see it('does not warn if requireResolversForResolveType is disabled and there are missing resolvers') */
+    public function testDoesNotWarnIfRequireResolversForResolveTypeIsDisabledAndThereAreMissingResolvers(): void
     {
         $resolvers = [
             'Query' => $this->queryResolver,

--- a/tests/SchemaGeneratorTest/TestHelper.php
+++ b/tests/SchemaGeneratorTest/TestHelper.php
@@ -6,7 +6,7 @@ namespace GraphQLTools\Tests\SchemaGeneratorTest;
 
 class TestHelper
 {
-    public static function getTestSchema() : string
+    public static function getTestSchema(): string
     {
         return '
             type RootQuery {
@@ -22,10 +22,8 @@ class TestHelper
         ';
     }
 
-    /**
-     * @return mixed[]
-     */
-    public static function getTestResolvers() : array
+    /** @return mixed[] */
+    public static function getTestResolvers(): array
     {
         return [
             '__schema' => static function () {
@@ -46,46 +44,44 @@ class TestHelper
                 },
                 'species' => static function ($root, $args) {
                     $name = $args['name'];
+
                     return $root['species'] . $name;
                 },
             ],
         ];
     }
 
-    public static function getTestConnector() : object
+    public static function getTestConnector(): object
     {
         return new class
         {
-            public function get() : string
+            public function get(): string
             {
                 return 'works';
             }
         };
     }
 
-    public static function getContextConnector(?object $ctx) : object
+    public static function getContextConnector(object|null $ctx): object
     {
         return new class ($ctx)
         {
-            /** @var string|null */
-            private $str;
+            private string|null $str = null;
 
-            public function __construct(?object $ctx)
+            public function __construct(object|null $ctx)
             {
                 $this->str = $ctx->str ?? null;
             }
 
-            public function get() : ?string
+            public function get(): string|null
             {
                 return $this->str;
             }
         };
     }
 
-    /**
-     * @return callable[]
-     */
-    public static function getTestConnectors() : array
+    /** @return callable[] */
+    public static function getTestConnectors(): array
     {
         return [
             'TestConnector' => [static::class, 'getTestConnector'],

--- a/tests/SchemaGeneratorTest/UnionsTest.php
+++ b/tests/SchemaGeneratorTest/UnionsTest.php
@@ -11,20 +11,19 @@ use Throwable;
 
 class UnionsTest extends TestCase
 {
-    /** @var string */
-    protected $testSchemaWithUnions;
+    protected string $testSchemaWithUnions;
     /** @var mixed[] */
-    protected $post;
+    protected array $post;
     /** @var mixed[] */
-    protected $page;
+    protected array $page;
     /** @var mixed[] */
-    protected $queryResolver;
-    /** @var string */
-    protected $query;
+    protected array $queryResolver;
+    protected string $query;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
+
         $this->testSchemaWithUnions = '
             type Post {
                 title: String!
@@ -68,10 +67,8 @@ class UnionsTest extends TestCase
         ';
     }
 
-    /**
-     * @see it('throws if there is no union resolveType resolver')
-     */
-    public function testThrowsIfThereIsNoUnionResolveTypeResolver() : void
+    /** @see it('throws if there is no union resolveType resolver') */
+    public function testThrowsIfThereIsNoUnionResolveTypeResolver(): void
     {
         $resolvers = [
             'Query' => $this->queryResolver,
@@ -89,10 +86,8 @@ class UnionsTest extends TestCase
         }
     }
 
-    /**
-     * @see it('does not throw if there is a resolveType resolver')
-     */
-    public function testDoesNotThrowIfThereIsAResolveTypeResolver() : void
+    /** @see it('does not throw if there is a resolveType resolver') */
+    public function testDoesNotThrowIfThereIsAResolveTypeResolver(): void
     {
         $resolvers = [
             'Query' => $this->queryResolver,
@@ -113,10 +108,8 @@ class UnionsTest extends TestCase
         static::assertEmpty($response->errors);
     }
 
-    /**
-     * @see it('does not warn if requireResolversForResolveType is disabled')
-     */
-    public function testDoesNotWarnIfRequireResolversForResolveTypeIsDisabled() : void
+    /** @see it('does not warn if requireResolversForResolveType is disabled') */
+    public function testDoesNotWarnIfRequireResolversForResolveTypeIsDisabled(): void
     {
         $resolvers = [
             'Query' => $this->queryResolver,

--- a/tests/TestingSchemas.php
+++ b/tests/TestingSchemas.php
@@ -15,6 +15,7 @@ use GraphQL\Language\AST\ValueNode;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Schema;
 use GraphQLTools\GraphQLTools;
+
 use function array_filter;
 use function array_map;
 use function array_slice;
@@ -24,10 +25,7 @@ use function json_encode;
 
 class TestingSchemas
 {
-    /**
-     * @param mixed $value
-     */
-    protected static function coerceString($value) : string
+    protected static function coerceString(mixed $value): string
     {
         if (is_array($value)) {
             throw new Error('String cannot represent an array value [' . $value . ']');
@@ -36,20 +34,12 @@ class TestingSchemas
         return (string) $value;
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @return mixed
-     */
-    protected static function identity($value)
+    protected static function identity(mixed $value): mixed
     {
         return $value;
     }
 
-    /**
-     * @return mixed
-     */
-    protected static function parseLiteral(ValueNode $ast)
+    protected static function parseLiteral(ValueNode $ast): mixed
     {
         if ($ast instanceof StringValueNode || $ast instanceof BooleanValueNode) {
             return $ast->value;
@@ -64,6 +54,7 @@ class TestingSchemas
             foreach ($ast->fields as $field) {
                 $value[$field->name->value] = static::parseLiteral($field->value);
             }
+
             return $value;
         }
 
@@ -76,7 +67,7 @@ class TestingSchemas
         return null;
     }
 
-    protected static function graphQLJSON() : CustomScalarType
+    protected static function graphQLJSON(): CustomScalarType
     {
         return new CustomScalarType([
             'name' => 'JSON',
@@ -94,7 +85,7 @@ class TestingSchemas
         ]);
     }
 
-    protected static function dateTime() : CustomScalarType
+    protected static function dateTime(): CustomScalarType
     {
         return new CustomScalarType([
             'name' => 'DateTime',
@@ -116,7 +107,7 @@ class TestingSchemas
     }
 
     /** @var mixed[] */
-    public static $sampleData = [
+    public static array $sampleData = [
         'Product' => [
             'pd1' => [
                 'id' => 'pd1',
@@ -217,7 +208,7 @@ class TestingSchemas
         ],
     ];
 
-    protected static function addressTypeDef() : string
+    protected static function addressTypeDef(): string
     {
         return '
             type Address {
@@ -229,7 +220,7 @@ class TestingSchemas
         ';
     }
 
-    protected static function propertyAddressTypeDef() : string
+    protected static function propertyAddressTypeDef(): string
     {
         return '
             type Property {
@@ -241,7 +232,7 @@ class TestingSchemas
         ';
     }
 
-    protected static function propertyRootTypeDefs() : string
+    protected static function propertyRootTypeDefs(): string
     {
         return '
             type Location {
@@ -296,7 +287,7 @@ class TestingSchemas
         ';
     }
 
-    protected static function propertyAddressTypeDefs() : string
+    protected static function propertyAddressTypeDefs(): string
     {
         $addressTypeDef         = static::addressTypeDef();
         $propertyAddressTypeDef = static::propertyAddressTypeDef();
@@ -312,10 +303,8 @@ class TestingSchemas
         ";
     }
 
-    /**
-     * @return mixed[]
-     */
-    protected static function propertyResolvers() : array
+    /** @return mixed[] */
+    protected static function propertyResolvers(): array
     {
         return [
             'Query' => [
@@ -366,10 +355,10 @@ class TestingSchemas
 
                     return ['someField' => 'Bar'];
                 },
-                'errorTest' => static function () : void {
+                'errorTest' => static function (): void {
                     throw new Error('Sample error!');
                 },
-                'errorTestNonNull' => static function () : void {
+                'errorTestNonNull' => static function (): void {
                     throw new Error('Sample error non-null!');
                 },
                 'defaultInputTest' => static function ($parent, $args) {
@@ -397,14 +386,14 @@ class TestingSchemas
                 },
             ],
             'Property' => [
-                'error' => static function () : void {
+                'error' => static function (): void {
                     throw new Error('Property.error error');
                 },
             ],
         ];
     }
 
-    protected static function customerAddressTypeDef() : string
+    protected static function customerAddressTypeDef(): string
     {
         return '
             type Customer implements Person {
@@ -419,7 +408,7 @@ class TestingSchemas
         ';
     }
 
-    protected static function bookingRootTypeDefs() : string
+    protected static function bookingRootTypeDefs(): string
     {
         return '
             scalar DateTime
@@ -464,7 +453,7 @@ class TestingSchemas
         ';
     }
 
-    protected static function bookingAddressTypeDefs() : string
+    protected static function bookingAddressTypeDefs(): string
     {
         $addressTypeDef         = static::addressTypeDef();
         $customerAddressTypeDef = static::customerAddressTypeDef();
@@ -477,10 +466,8 @@ class TestingSchemas
         ";
     }
 
-    /**
-     * @return mixed[]
-     */
-    protected static function bookingResolvers() : array
+    /** @return mixed[] */
+    protected static function bookingResolvers(): array
     {
         return [
             'Query' => [
@@ -547,10 +534,10 @@ class TestingSchemas
                 'customer' => static function ($parent) {
                     return static::$sampleData['Customer'][$parent['customerId']];
                 },
-                'error' => static function () : void {
+                'error' => static function (): void {
                     throw new Error('Booking.error error');
                 },
-                'errorNonNull' => static function () : void {
+                'errorNonNull' => static function (): void {
                     throw new Error('Booking.errorNoNull error');
                 },
             ],
@@ -570,7 +557,7 @@ class TestingSchemas
                 'vehicle' => static function ($parent) {
                     return static::$sampleData['Vehicle'][$parent['vehicleId']];
                 },
-                'error' => static function () : void {
+                'error' => static function (): void {
                     throw new Error('Customer.error error');
                 },
             ],
@@ -591,7 +578,7 @@ class TestingSchemas
         ];
     }
 
-    public static function propertySchema() : Schema
+    public static function propertySchema(): Schema
     {
         return GraphQLTools::makeExecutableSchema([
             'typeDefs' => static::propertyAddressTypeDefs(),
@@ -599,7 +586,7 @@ class TestingSchemas
         ]);
     }
 
-    public static function bookingSchema() : Schema
+    public static function bookingSchema(): Schema
     {
         return GraphQLTools::makeExecutableSchema([
             'typeDefs' => static::bookingAddressTypeDefs(),

--- a/tests/TransformsTest/FilterToSchemaTest.php
+++ b/tests/TransformsTest/FilterToSchemaTest.php
@@ -10,24 +10,20 @@ use GraphQLTools\Tests\TestingSchemas;
 use GraphQLTools\Transforms\FilterToSchema;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @see describe('filter to schema')
- */
+/** @see describe('filter to schema') */
 class FilterToSchemaTest extends TestCase
 {
-    /** @var FilterToSchema */
-    protected $filter;
+    protected FilterToSchema $filter;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
+
         $this->filter = new FilterToSchema(TestingSchemas::bookingSchema());
     }
 
-    /**
-     * @see it('should remove empty selection sets on objects')
-     */
-    public function testShouldRemoveEmptySelectionSetsOnObjects() : void
+    /** @see it('should remove empty selection sets on objects') */
+    public function testShouldRemoveEmptySelectionSetsOnObjects(): void
     {
         $query = Parser::parse('
             query customerQuery($id: ID!) {
@@ -58,10 +54,8 @@ class FilterToSchemaTest extends TestCase
         static::assertEquals(Printer::doPrint($expected), Printer::doPrint($filteredQuery['document']));
     }
 
-    /**
-     * @see it('should also remove variables when removing empty selection sets')
-     */
-    public function testShouldAlsoRemoveVariablesWhenRemovingEmptySelectionSets() : void
+    /** @see it('should also remove variables when removing empty selection sets') */
+    public function testShouldAlsoRemoveVariablesWhenRemovingEmptySelectionSets(): void
     {
         $query = Parser::parse('
             query customerQuery($id: ID!, $limit: Int) {
@@ -95,10 +89,8 @@ class FilterToSchemaTest extends TestCase
         static::assertEquals(Printer::doPrint($expected), Printer::doPrint($filteredQuery['document']));
     }
 
-    /**
-     * @see it('should remove empty selection sets on wrapped objects (non-nullable/lists)')
-     */
-    public function testShouldRemoveEmptySelectionSetsOnWrappedObjectsNonNullableLists() : void
+    /** @see it('should remove empty selection sets on wrapped objects (non-nullable/lists)') */
+    public function testShouldRemoveEmptySelectionSetsOnWrappedObjectsNonNullableLists(): void
     {
         $query = Parser::parse('
             query bookingQuery($id: ID!) {

--- a/tests/TransformsTest/FilterTypeTest.php
+++ b/tests/TransformsTest/FilterTypeTest.php
@@ -10,34 +10,32 @@ use GraphQLTools\GraphQLTools;
 use GraphQLTools\Tests\TestingSchemas;
 use GraphQLTools\Transforms\FilterTypes;
 use PHPUnit\Framework\TestCase;
+
 use function in_array;
 
-/**
- * @see describe('filter type')
- */
+/** @see describe('filter type') */
 class FilterTypeTest extends TestCase
 {
-    /** @var Schema */
-    protected $schema;
+    protected Schema $schema;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
+
         $typeNames  = ['ID', 'String', 'DateTime', 'Query', 'Booking'];
-        $transforms = [new FilterTypes(
-            static function ($type) use ($typeNames) {
+        $transforms = [
+            new FilterTypes(
+                static function ($type) use ($typeNames) {
                     return in_array($type->name, $typeNames);
-            }
-        ),
+                },
+            ),
         ];
 
         $this->schema = GraphQLTools::transformSchema(TestingSchemas::bookingSchema(), $transforms);
     }
 
-    /**
-     * @see it('should work normally')
-     */
-    public function testShouldWorkNormally() : void
+    /** @see it('should work normally') */
+    public function testShouldWorkNormally(): void
     {
         $result = GraphQL::executeQuery(
             $this->schema,
@@ -50,7 +48,7 @@ class FilterTypeTest extends TestCase
                         endTime
                     }
                 }
-            '
+            ',
         );
 
         static::assertEquals(
@@ -64,14 +62,12 @@ class FilterTypeTest extends TestCase
                     ],
                 ],
             ],
-            $result->toArray()
+            $result->toArray(),
         );
     }
 
-    /**
-     * @see it('should error on removed types')
-     */
-    public function testShouldErrorOnRemovedTypes() : void
+    /** @see it('should error on removed types') */
+    public function testShouldErrorOnRemovedTypes(): void
     {
         $result = GraphQL::executeQuery(
             $this->schema,
@@ -87,14 +83,14 @@ class FilterTypeTest extends TestCase
                         }
                     }
                 }
-            '
+            ',
         );
 
         static::assertNotEmpty($result->errors);
         static::assertCount(1, $result->errors);
         static::assertEquals(
             'Cannot query field "customer" on type "Booking".',
-            $result->errors[0]->getMessage()
+            $result->errors[0]->getMessage(),
         );
     }
 }

--- a/tests/TransformsTest/NamespaceTest.php
+++ b/tests/TransformsTest/NamespaceTest.php
@@ -11,29 +11,26 @@ use GraphQLTools\Tests\TestingSchemas;
 use GraphQLTools\Transforms\RenameTypes;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @see describe('namespace')
- */
+/** @see describe('namespace') */
 class NamespaceTest extends TestCase
 {
-    /** @var Schema */
-    protected $schema;
+    protected Schema $schema;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
-        $transforms = [new RenameTypes(static function ($name) {
+
+        $transforms = [
+            new RenameTypes(static function ($name) {
                 return 'Property_' . $name;
-        }),
+            }),
         ];
 
         $this->schema = GraphQLTools::transformSchema(TestingSchemas::propertySchema(), $transforms);
     }
 
-    /**
-     * @see it('should work')
-     */
-    public function testShouldWork() : void
+    /** @see it('should work') */
+    public function testShouldWork(): void
     {
         $result = GraphQL::executeQuery(
             $this->schema,
@@ -61,7 +58,7 @@ class NamespaceTest extends TestCase
             [],
             [
                 'input' => ['test' => 'bar'],
-            ]
+            ],
         );
 
         static::assertEquals(
@@ -79,7 +76,7 @@ class NamespaceTest extends TestCase
                     'propertyById' => ['id' => 'p1'],
                 ],
             ],
-            $result->toArray()
+            $result->toArray(),
         );
     }
 }

--- a/tests/TransformsTest/RenameTypeTest.php
+++ b/tests/TransformsTest/RenameTypeTest.php
@@ -11,20 +11,18 @@ use GraphQLTools\Tests\TestingSchemas;
 use GraphQLTools\Transforms\RenameTypes;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @see describe('rename type')
- */
+/** @see describe('rename type') */
 class RenameTypeTest extends TestCase
 {
-    /** @var Schema */
-    protected $schema;
+    protected Schema $schema;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
 
-        $transforms = [new RenameTypes(
-            static function ($name) {
+        $transforms = [
+            new RenameTypes(
+                static function ($name) {
                     return [
                         'Property' => 'House',
                         'Location' => 'Spots',
@@ -34,17 +32,15 @@ class RenameTypeTest extends TestCase
                         'TestInterfaceKind' => 'TestingInterfaceKinds',
                         'TestImpl1' => 'TestImplementation1',
                     ][$name] ?? null;
-            }
-        ),
+                },
+            ),
         ];
 
         $this->schema = GraphQLTools::transformSchema(TestingSchemas::propertySchema(), $transforms);
     }
 
-    /**
-     * @see it('should work')
-     */
-    public function testShouldWork() : void
+    /** @see it('should work') */
+    public function testShouldWork(): void
     {
         $result = GraphQL::executeQuery(
             $this->schema,
@@ -68,7 +64,7 @@ class RenameTypeTest extends TestCase
             [],
             [
                 'input' => ['test' => 'bar'],
-            ]
+            ],
         );
 
         static::assertEquals(
@@ -80,7 +76,7 @@ class RenameTypeTest extends TestCase
                     'propertyById' => ['id' => 'p1'],
                 ],
             ],
-            $result->toArray()
+            $result->toArray(),
         );
     }
 }

--- a/tests/TransformsTest/ReplacesFieldWithFragmentsTest.php
+++ b/tests/TransformsTest/ReplacesFieldWithFragmentsTest.php
@@ -10,21 +10,18 @@ use GraphQLTools\GraphQLTools;
 use GraphQLTools\Transforms\ReplaceFieldWithFragment;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @see describe('replaces field with fragments')
- */
+/** @see describe('replaces field with fragments') */
 class ReplacesFieldWithFragmentsTest extends TestCase
 {
     /** @var mixed[] */
-    protected $data;
-    /** @var Schema */
-    protected $subSchema;
-    /** @var Schema */
-    protected $schema;
+    protected array $data;
+    protected Schema $subSchema;
+    protected Schema $schema;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
+
         $this->data = [
             'u1' => [
                 'id' => 'u1',
@@ -69,6 +66,7 @@ class ReplacesFieldWithFragmentsTest extends TestCase
                 'Query' => [
                     'userById' => function ($parent, $args, $context, $info) {
                         $id = $args['id'];
+
                         return GraphQLTools::delegateToSchema([
                             'schema' => $this->subSchema,
                             'operation' => 'query',
@@ -76,19 +74,20 @@ class ReplacesFieldWithFragmentsTest extends TestCase
                             'args' => ['id' => $id],
                             'context' => $context,
                             'info' => $info,
-                            'transforms' => [new ReplaceFieldWithFragment(
-                                $this->subSchema,
-                                [
+                            'transforms' => [
+                                new ReplaceFieldWithFragment(
+                                    $this->subSchema,
                                     [
-                                        'field' => 'fullname',
-                                        'fragment' => 'fragment UserName on User { name }',
+                                        [
+                                            'field' => 'fullname',
+                                            'fragment' => 'fragment UserName on User { name }',
+                                        ],
+                                        [
+                                            'field' => 'fullname',
+                                            'fragment' => 'fragment UserSurname on User { surname }',
+                                        ],
                                     ],
-                                    [
-                                        'field' => 'fullname',
-                                        'fragment' => 'fragment UserSurname on User { surname }',
-                                    ],
-                                ]
-                            ),
+                                ),
                             ],
                         ]);
                     },
@@ -102,10 +101,8 @@ class ReplacesFieldWithFragmentsTest extends TestCase
         ]);
     }
 
-    /**
-     * @see it('should work')
-     */
-    public function testShouldWork() : void
+    /** @see it('should work') */
+    public function testShouldWork(): void
     {
         $result = GraphQL::executeQuery(
             $this->schema,
@@ -116,7 +113,7 @@ class ReplacesFieldWithFragmentsTest extends TestCase
                         fullname
                     }
                 }
-            '
+            ',
         );
 
         static::assertEquals(
@@ -128,7 +125,7 @@ class ReplacesFieldWithFragmentsTest extends TestCase
                     ],
                 ],
             ],
-            $result->toArray()
+            $result->toArray(),
         );
     }
 }

--- a/tests/TransformsTest/TreeOperationsTest.php
+++ b/tests/TransformsTest/TreeOperationsTest.php
@@ -12,20 +12,20 @@ use GraphQLTools\GraphQLTools;
 use GraphQLTools\Transforms\ExtractField;
 use GraphQLTools\Transforms\WrapQuery;
 use PHPUnit\Framework\TestCase;
+
 use function array_merge;
 
 class TreeOperationsTest extends TestCase
 {
     /** @var mixed[] */
-    protected $data;
-    /** @var Schema */
-    protected $subSchema;
-    /** @var Schema */
-    protected $schema;
+    protected array $data;
+    protected Schema $subSchema;
+    protected Schema $schema;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
+
         $this->data = [
             'u1' => [
                 'id' => 'u1',
@@ -85,7 +85,7 @@ class TreeOperationsTest extends TestCase
                         if (isset($this->data[$input['id']])) {
                             return array_merge(
                                 $this->data[$input['id']],
-                                $input
+                                $input,
                             );
                         }
 
@@ -96,7 +96,7 @@ class TreeOperationsTest extends TestCase
                         if (isset($this->data[$input['id']])) {
                             return array_merge(
                                 $this->data[$input['id']]['address'],
-                                $input
+                                $input,
                             );
                         }
 
@@ -134,6 +134,7 @@ class TreeOperationsTest extends TestCase
                 'Query' => [
                     'addressByUser' => function ($parent, $args, $context, $info) {
                         $id = $args['id'];
+
                         return GraphQLTools::delegateToSchema([
                             'schema' => $this->subSchema,
                             'operation' => 'query',
@@ -158,7 +159,7 @@ class TreeOperationsTest extends TestCase
                                     // how to process the data result at path
                                     static function ($result) {
                                         return $result ? $result['address'] : null;
-                                    }
+                                    },
                                 ),
                             ],
                         ]);
@@ -206,7 +207,7 @@ class TreeOperationsTest extends TestCase
 
                         return array_merge(
                             $userResult,
-                            ['address' => $addressResult]
+                            ['address' => $addressResult],
                         );
                     },
                 ],
@@ -214,10 +215,8 @@ class TreeOperationsTest extends TestCase
         ]);
     }
 
-    /**
-     * @see it('wrapping delegation')
-     */
-    public function testWrappingDelegation() : void
+    /** @see it('wrapping delegation') */
+    public function testWrappingDelegation(): void
     {
         $result = GraphQL::executeQuery(
             $this->schema,
@@ -228,7 +227,7 @@ class TreeOperationsTest extends TestCase
                         zip
                     }
                 }
-            '
+            ',
         );
 
         static::assertEquals(
@@ -240,14 +239,12 @@ class TreeOperationsTest extends TestCase
                     ],
                 ],
             ],
-            $result->toArray()
+            $result->toArray(),
         );
     }
 
-    /**
-     * @see it('extracting delegation')
-     */
-    public function testExtractingDelegation() : void
+    /** @see it('extracting delegation') */
+    public function testExtractingDelegation(): void
     {
         $result = GraphQL::executeQuery(
             $this->schema,
@@ -281,7 +278,7 @@ class TreeOperationsTest extends TestCase
                     'streetAddress' => 'New Address 555',
                     'zip' => '22222',
                 ],
-            ]
+            ],
         );
 
         static::assertEquals(
@@ -296,7 +293,7 @@ class TreeOperationsTest extends TestCase
                     ],
                 ],
             ],
-            $result->toArray()
+            $result->toArray(),
         );
     }
 }

--- a/tests/TransformsTest/WrapQueryTest.php
+++ b/tests/TransformsTest/WrapQueryTest.php
@@ -94,7 +94,7 @@ class WrapQueryTest extends TestCase
                                     ['userById'],
                                     static function ($subtree) {
                                         return new SelectionSetNode([
-                                            'selections' => NodeList::create(array_map(
+                                            'selections' => new NodeList(array_map(
                                                 static function ($selection) {
                                                     // just append fragments, not interesting for this
                                                     // test

--- a/tests/TransformsTest/WrapQueryTest.php
+++ b/tests/TransformsTest/WrapQueryTest.php
@@ -9,10 +9,12 @@ use GraphQL\Language\AST\FieldNode;
 use GraphQL\Language\AST\FragmentSpreadNode;
 use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\NameNode;
+use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\SelectionSetNode;
 use GraphQL\Type\Schema;
 use GraphQLTools\GraphQLTools;
 use GraphQLTools\Transforms\WrapQuery;
+use GraphQLTools\Utils;
 use PHPUnit\Framework\TestCase;
 
 use function array_map;
@@ -92,7 +94,7 @@ class WrapQueryTest extends TestCase
                                     ['userById'],
                                     static function ($subtree) {
                                         return new SelectionSetNode([
-                                            'selections' => array_map(
+                                            'selections' => NodeList::create(array_map(
                                                 static function ($selection) {
                                                     // just append fragments, not interesting for this
                                                     // test
@@ -115,8 +117,8 @@ class WrapQueryTest extends TestCase
                                                         ]),
                                                     ]);
                                                 },
-                                                $subtree->selections,
-                                            ),
+                                                Utils::toArray($subtree->selections),
+                                            )),
                                         ]);
                                     },
                                     static function ($result) {

--- a/tests/TransformsTest/WrapQueryTest.php
+++ b/tests/TransformsTest/WrapQueryTest.php
@@ -14,6 +14,7 @@ use GraphQL\Type\Schema;
 use GraphQLTools\GraphQLTools;
 use GraphQLTools\Transforms\WrapQuery;
 use PHPUnit\Framework\TestCase;
+
 use function array_map;
 use function strtoupper;
 use function substr;
@@ -21,15 +22,14 @@ use function substr;
 class WrapQueryTest extends TestCase
 {
     /** @var mixed[] */
-    protected $data;
-    /** @var Schema */
-    protected $subSchema;
-    /** @var Schema */
-    protected $schema;
+    protected array $data;
+    protected Schema $subSchema;
+    protected Schema $schema;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
+
         $this->data      = [
             'u1' => [
                 'id' => 'user1',
@@ -52,6 +52,7 @@ class WrapQueryTest extends TestCase
                 'Query' => [
                     'userById' => function ($parent, $args) {
                         $id = $args['id'];
+
                         return $this->data[$id];
                     },
                 ],
@@ -76,6 +77,7 @@ class WrapQueryTest extends TestCase
                 'Query' => [
                     'addressByUser' => function ($parent, $args, $context, $info) {
                         $id = $args['id'];
+
                         return GraphQLTools::delegateToSchema([
                             'schema' => $this->subSchema,
                             'operation' => 'query',
@@ -94,8 +96,10 @@ class WrapQueryTest extends TestCase
                                                 static function ($selection) {
                                                     // just append fragments, not interesting for this
                                                     // test
-                                                    if ($selection instanceof InlineFragmentNode
-                                                        || $selection instanceof FragmentSpreadNode) {
+                                                    if (
+                                                        $selection instanceof InlineFragmentNode
+                                                        || $selection instanceof FragmentSpreadNode
+                                                    ) {
                                                         return $selection;
                                                     }
 
@@ -111,7 +115,7 @@ class WrapQueryTest extends TestCase
                                                         ]),
                                                     ]);
                                                 },
-                                                $subtree->selections
+                                                $subtree->selections,
                                             ),
                                         ]);
                                     },
@@ -120,7 +124,7 @@ class WrapQueryTest extends TestCase
                                             'streetAddress' => $result['addressStreetAddress'],
                                             'zip' => $result['addressZip'],
                                         ];
-                                    }
+                                    },
                                 ),
                             ],
                         ]);
@@ -130,10 +134,8 @@ class WrapQueryTest extends TestCase
         ]);
     }
 
-    /**
-     * @see it('wrapping delegation, returning selectionSet')
-     */
-    public function testWrappingDelegationReturningSelectionSet() : void
+    /** @see it('wrapping delegation, returning selectionSet') */
+    public function testWrappingDelegationReturningSelectionSet(): void
     {
         $result = GraphQL::executeQuery(
             $this->schema,
@@ -144,7 +146,7 @@ class WrapQueryTest extends TestCase
                     zip
                 }
             }
-        '
+        ',
         );
 
         static::assertEquals(
@@ -156,7 +158,7 @@ class WrapQueryTest extends TestCase
                     ],
                 ],
             ],
-            $result->toArray()
+            $result->toArray(),
         );
     }
 }


### PR DESCRIPTION
Without this, the complexity calculation gets lost on `GraphQLTools::transformSchema()`.

This function is used inside the `SchemaService` of the t3n/graphql package. It causes the cost directive calculation to be always (re-)calculated with value 1.